### PR TITLE
Moved FadePageTransformer and PagerAdapter into separate files

### DIFF
--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
@@ -7,8 +7,6 @@ import android.os.Bundle;
 import android.os.Vibrator;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.view.View;
 import android.view.Window;
@@ -199,44 +197,4 @@ public abstract class AppIntro extends FragmentActivity {
     public abstract void init(Bundle savedInstanceState);
     public abstract void onSkipPressed();
     public abstract void onDonePressed();
-
-    public class PagerAdapter extends FragmentPagerAdapter {
-
-        private List<Fragment> fragments;
-
-        public PagerAdapter(FragmentManager fm, List<Fragment> fragments) {
-            super(fm);
-            this.fragments = fragments;
-        }
-
-        @Override
-        public Fragment getItem(int position) {
-            return this.fragments.get(position);
-        }
-
-        @Override
-        public int getCount() {
-            return this.fragments.size();
-        }
-
-        public List<Fragment> getFragments() {
-            return fragments;
-        }
-
-    }
-
-    public class FadePageTransformer implements ViewPager.PageTransformer {
-        public void transformPage(View view, float position) {
-            view.setTranslationX(view.getWidth() * -position);
-
-            if(position <= -1.0F || position >= 1.0F) {
-                view.setAlpha(0.0F);
-            } else if( position == 0.0F ) {
-                view.setAlpha(1.0F);
-            } else {
-                // position is between -1.0F & 0.0F OR 0.0F & 1.0F
-                view.setAlpha(1.0F - Math.abs(position));
-            }
-        }
-    }
 }

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
@@ -7,8 +7,6 @@ import android.os.Bundle;
 import android.os.Vibrator;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.view.View;
 import android.view.Window;
@@ -152,43 +150,4 @@ public abstract class AppIntro2 extends FragmentActivity {
 
     public abstract void init(Bundle savedInstanceState);
     public abstract void onDonePressed();
-
-    public class PagerAdapter extends FragmentPagerAdapter {
-
-        private List<Fragment> fragments;
-
-        public PagerAdapter(FragmentManager fm, List<Fragment> fragments) {
-            super(fm);
-            this.fragments = fragments;
-        }
-
-        @Override
-        public Fragment getItem(int position) {
-            return this.fragments.get(position);
-        }
-
-        @Override
-        public int getCount() {
-            return this.fragments.size();
-        }
-
-        public List<Fragment> getFragments() {
-            return fragments;
-        }
-    }
-
-    public class FadePageTransformer implements ViewPager.PageTransformer {
-        public void transformPage(View view, float position) {
-            view.setTranslationX(view.getWidth() * -position);
-
-            if(position <= -1.0F || position >= 1.0F) {
-                view.setAlpha(0.0F);
-            } else if( position == 0.0F ) {
-                view.setAlpha(1.0F);
-            } else {
-                // position is between -1.0F & 0.0F OR 0.0F & 1.0F
-                view.setAlpha(1.0F - Math.abs(position));
-            }
-        }
-    }
 }

--- a/library/src/main/java/com/github/paolorotolo/appintro/FadePageTransformer.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/FadePageTransformer.java
@@ -1,0 +1,20 @@
+package com.github.paolorotolo.appintro;
+
+import android.support.v4.view.ViewPager;
+import android.view.View;
+
+class FadePageTransformer implements ViewPager.PageTransformer {
+    @Override
+    public void transformPage(View view, float position) {
+        view.setTranslationX(view.getWidth() * -position);
+
+        if (position <= -1.0F || position >= 1.0F) {
+            view.setAlpha(0.0F);
+        } else if (position == 0.0F) {
+            view.setAlpha(1.0F);
+        } else {
+            // position is between -1.0F & 0.0F OR 0.0F & 1.0F
+            view.setAlpha(1.0F - Math.abs(position));
+        }
+    }
+}

--- a/library/src/main/java/com/github/paolorotolo/appintro/PagerAdapter.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/PagerAdapter.java
@@ -1,0 +1,30 @@
+package com.github.paolorotolo.appintro;
+
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+
+import java.util.List;
+
+class PagerAdapter extends FragmentPagerAdapter {
+    private List<Fragment> fragments;
+
+    public PagerAdapter(FragmentManager fm, List<Fragment> fragments) {
+        super(fm);
+        this.fragments = fragments;
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+        return this.fragments.get(position);
+    }
+
+    @Override
+    public int getCount() {
+        return this.fragments.size();
+    }
+
+    public List<Fragment> getFragments() {
+        return fragments;
+    }
+}


### PR DESCRIPTION
The ``FadePageTransformer`` and ``PagerAdapter`` where exactly the same inside ``AppIntro`` and ``AppIntro2``. I just moved them into separate files so there is no need to define them twice.

**Warning**: Both classes are now _package local_ instead of _public_ so this could be an API breaker. But there should be no reason to derive from this classes because the are intended for internal use only in my opinion. 
To take the safe route consider bumping the version number to 2.0.0 for the next release if you use [semantic versioning](http://semver.org/).