### PR TITLE
Annotated all method parameters and return values with android annotations

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,4 +24,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:support-v4:22.2.0'
+    compile 'com.android.support:support-annotations:22.2.0'
 }

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
@@ -5,6 +5,9 @@ import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Vibrator;
+import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.ViewPager;
@@ -14,6 +17,7 @@ import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
@@ -21,7 +25,7 @@ import java.util.Vector;
 public abstract class AppIntro extends FragmentActivity {
     private PagerAdapter mPagerAdapter;
     private ViewPager pager;
-    private List<Fragment> fragments = new Vector<Fragment>();
+    private List<Fragment> fragments = new Vector<>();
     private List<ImageView> dots;
     private int slidesNumber;
     private Vibrator mVibrator;
@@ -29,7 +33,7 @@ public abstract class AppIntro extends FragmentActivity {
     private int vibrateIntensity = 20;
     private boolean showSkip = true;
 
-    private static int FIRST_PAGE_NUM = 0;
+    private static final int FIRST_PAGE_NUM = 0;
 
     @Override
     final protected void onCreate(Bundle savedInstanceState) {
@@ -47,7 +51,7 @@ public abstract class AppIntro extends FragmentActivity {
 
         skipButton.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View v) {
+            public void onClick(@NonNull View v) {
                 if (isVibrateOn) {
                     mVibrator.vibrate(vibrateIntensity);
                 }
@@ -55,19 +59,19 @@ public abstract class AppIntro extends FragmentActivity {
             }
         });
 
-        nextButton.setOnClickListener(new View.OnClickListener(){
+        nextButton.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View v) {
+            public void onClick(@NonNull View v) {
                 if (isVibrateOn) {
                     mVibrator.vibrate(vibrateIntensity);
                 }
-                pager.setCurrentItem(pager.getCurrentItem()+1);
+                pager.setCurrentItem(pager.getCurrentItem() + 1);
             }
         });
 
         doneButton.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View v) {
+            public void onClick(@NonNull View v) {
                 if (isVibrateOn) {
                     mVibrator.vibrate(vibrateIntensity);
                 }
@@ -81,13 +85,12 @@ public abstract class AppIntro extends FragmentActivity {
         pager.setOnPageChangeListener(new ViewPager.OnPageChangeListener() {
             @Override
             public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-                
             }
 
             @Override
             public void onPageSelected(int position) {
                 selectDot(position);
-                if (position == slidesNumber - 1){
+                if (position == slidesNumber - 1) {
                     skipButton.setVisibility(View.INVISIBLE);
                     nextButton.setVisibility(View.GONE);
                     doneButton.setVisibility(View.VISIBLE);
@@ -97,7 +100,7 @@ public abstract class AppIntro extends FragmentActivity {
                     nextButton.setVisibility(View.VISIBLE);
                 }
 
-                if (!showSkip){
+                if (!showSkip) {
                     skipButton.setVisibility(View.INVISIBLE);
                 }
             }
@@ -141,60 +144,63 @@ public abstract class AppIntro extends FragmentActivity {
         }
     }
 
-    public void addSlide(Fragment fragment, Context context) {
+    public void addSlide(@NonNull Fragment fragment, @NonNull Context context) {
         fragments.add(Fragment.instantiate(context, fragment.getClass().getName()));
         mPagerAdapter.notifyDataSetChanged();
     }
 
+    @NonNull
     public List<Fragment> getSlides() {
         return mPagerAdapter.getFragments();
     }
 
-    public void setBarColor(final int color){
+    public void setBarColor(@ColorInt final int color) {
         LinearLayout bottomBar = (LinearLayout) findViewById(R.id.bottom);
         bottomBar.setBackgroundColor(color);
     }
 
-    public void setSeparatorColor(final int color){
+    public void setSeparatorColor(@ColorInt final int color) {
         TextView separator = (TextView) findViewById(R.id.bottom_separator);
         separator.setBackgroundColor(color);
     }
 
-    public void setSkipText(final String text){
+    public void setSkipText(@Nullable final String text) {
         TextView skipText = (TextView) findViewById(R.id.skip);
         skipText.setText(text);
     }
 
-    public void setDoneText(final String text){
+    public void setDoneText(@Nullable final String text) {
         TextView doneText = (TextView) findViewById(R.id.done);
         doneText.setText(text);
     }
 
-    public void showSkipButton(boolean showButton){
+    public void showSkipButton(boolean showButton) {
         this.showSkip = showButton;
-        if (!showButton){
+        if (!showButton) {
             TextView skip = (TextView) findViewById(R.id.skip);
             skip.setVisibility(View.INVISIBLE);
         }
     }
 
-    public void setVibrate(boolean vibrate){
+    public void setVibrate(boolean vibrate) {
         this.isVibrateOn = vibrate;
     }
 
-    public void setVibrateIntensity(int intensity){
+    public void setVibrateIntensity(int intensity) {
         this.vibrateIntensity = intensity;
     }
 
-    public void setFadeAnimation(){
+    public void setFadeAnimation() {
         pager.setPageTransformer(true, new FadePageTransformer());
     }
 
-    public void setCustomTransformer(ViewPager.PageTransformer transformer){
+    public void setCustomTransformer(@Nullable ViewPager.PageTransformer transformer) {
         pager.setPageTransformer(true, transformer);
     }
 
-    public abstract void init(Bundle savedInstanceState);
+    public abstract void init(@Nullable Bundle savedInstanceState);
+
     public abstract void onSkipPressed();
+
     public abstract void onDonePressed();
 }

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
@@ -5,6 +5,8 @@ import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Vibrator;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.ViewPager;
@@ -21,14 +23,14 @@ import java.util.Vector;
 public abstract class AppIntro2 extends FragmentActivity {
     private PagerAdapter mPagerAdapter;
     private ViewPager pager;
-    private List<Fragment> fragments = new Vector<Fragment>();
+    private List<Fragment> fragments = new Vector<>();
     private List<ImageView> dots;
     private int slidesNumber;
     private Vibrator mVibrator;
     private boolean isVibrateOn = false;
     private int vibrateIntensity = 20;
 
-    private static int FIRST_PAGE_NUM = 0;
+    private static final int FIRST_PAGE_NUM = 0;
 
     @Override
     final protected void onCreate(Bundle savedInstanceState) {
@@ -43,19 +45,19 @@ public abstract class AppIntro2 extends FragmentActivity {
         final ImageView doneButton = (ImageView) findViewById(R.id.done);
         mVibrator = (Vibrator) this.getSystemService(VIBRATOR_SERVICE);
 
-        nextButton.setOnClickListener(new View.OnClickListener(){
+        nextButton.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View v) {
+            public void onClick(@NonNull View v) {
                 if (isVibrateOn) {
                     mVibrator.vibrate(vibrateIntensity);
                 }
-                pager.setCurrentItem(pager.getCurrentItem()+1);
+                pager.setCurrentItem(pager.getCurrentItem() + 1);
             }
         });
 
         doneButton.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View v) {
+            public void onClick(@NonNull View v) {
                 if (isVibrateOn) {
                     mVibrator.vibrate(vibrateIntensity);
                 }
@@ -69,13 +71,12 @@ public abstract class AppIntro2 extends FragmentActivity {
         pager.setOnPageChangeListener(new ViewPager.OnPageChangeListener() {
             @Override
             public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-
             }
 
             @Override
             public void onPageSelected(int position) {
                 selectDot(position);
-                if (position == slidesNumber - 1){
+                if (position == slidesNumber - 1) {
                     nextButton.setVisibility(View.GONE);
                     doneButton.setVisibility(View.VISIBLE);
                 } else {
@@ -123,31 +124,33 @@ public abstract class AppIntro2 extends FragmentActivity {
         }
     }
 
-    public void addSlide(Fragment fragment, Context context) {
+    public void addSlide(@NonNull Fragment fragment, @NonNull Context context) {
         fragments.add(Fragment.instantiate(context, fragment.getClass().getName()));
         mPagerAdapter.notifyDataSetChanged();
     }
 
+    @NonNull
     public List<Fragment> getSlides() {
         return mPagerAdapter.getFragments();
     }
 
-    public void setVibrate(boolean vibrate){
+    public void setVibrate(boolean vibrate) {
         this.isVibrateOn = vibrate;
     }
 
-    public void setVibrateIntensity(int intensity){
+    public void setVibrateIntensity(int intensity) {
         this.vibrateIntensity = intensity;
     }
 
-    public void setFadeAnimation(){
+    public void setFadeAnimation() {
         pager.setPageTransformer(true, new FadePageTransformer());
     }
 
-    public void setCustomTransformer(ViewPager.PageTransformer transformer){
+    public void setCustomTransformer(@Nullable ViewPager.PageTransformer transformer) {
         pager.setPageTransformer(true, transformer);
     }
 
-    public abstract void init(Bundle savedInstanceState);
+    public abstract void init(@Nullable Bundle savedInstanceState);
+
     public abstract void onDonePressed();
 }

--- a/library/src/main/java/com/github/paolorotolo/appintro/PagerAdapter.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/PagerAdapter.java
@@ -1,5 +1,6 @@
 package com.github.paolorotolo.appintro;
 
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
@@ -9,7 +10,7 @@ import java.util.List;
 class PagerAdapter extends FragmentPagerAdapter {
     private List<Fragment> fragments;
 
-    public PagerAdapter(FragmentManager fm, List<Fragment> fragments) {
+    public PagerAdapter(FragmentManager fm, @NonNull List<Fragment> fragments) {
         super(fm);
         this.fragments = fragments;
     }
@@ -24,6 +25,7 @@ class PagerAdapter extends FragmentPagerAdapter {
         return this.fragments.size();
     }
 
+    @NonNull
     public List<Fragment> getFragments() {
         return fragments;
     }


### PR DESCRIPTION
To improve auto detection of invalid parameters and unexpected return values I annotated all method parameters and return values with the corresponding android annotations.

This gives you warnings directly in IntelliJ and Android Studio (and Lint I guess) when you try to:
- pass a resource id to ``setBarColor`` or ``setSeparatorColor`` instead of a resolved color
- pass _null_ for _Fragment_ or _Context_ to ``addSlide``

Also you get an informational hint that you don't need to check the result of ``getSlides`` for _null_ because it is never _null_ if you do so.