### PR TITLE
Remove deprecation warning for Resources.getDrawable(int)

### DIFF
--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntroFragment.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntroFragment.java
@@ -57,7 +57,7 @@ public class AppIntroFragment extends Fragment {
         LinearLayout m = (LinearLayout) v.findViewById(R.id.main);
         t.setText(title);
         d.setText(description);
-        i.setImageDrawable(getResources().getDrawable(drawable));
+        i.setImageDrawable(ResourceUtils.getDrawable(getActivity(), drawable));
         m.setBackgroundColor(colour);
         return v;
     }

--- a/library/src/main/java/com/github/paolorotolo/appintro/DefaultIndicatorController.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/DefaultIndicatorController.java
@@ -2,8 +2,6 @@ package com.github.paolorotolo.appintro;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
-import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.ImageView;
@@ -34,7 +32,7 @@ class DefaultIndicatorController implements IndicatorController {
 
         for (int i = 0; i < slideCount; i++) {
             ImageView dot = new ImageView(mContext);
-            dot.setImageDrawable(getDrawable(R.drawable.indicator_dot_grey));
+            dot.setImageDrawable(ResourceUtils.getDrawable(mContext, R.drawable.indicator_dot_grey));
 
             LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.WRAP_CONTENT,
@@ -52,16 +50,8 @@ class DefaultIndicatorController implements IndicatorController {
     public void selectPosition(int index) {
         for (int i = 0; i < mSlideCount; i++) {
             int drawableId = (i == index) ? (R.drawable.indicator_dot_white) : (R.drawable.indicator_dot_grey);
-            Drawable drawable = getDrawable(drawableId);
+            Drawable drawable = ResourceUtils.getDrawable(mContext, drawableId);
             mDots.get(i).setImageDrawable(drawable);
         }
-    }
-
-    private Drawable getDrawable(@DrawableRes int drawableId) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            return mContext.getDrawable(drawableId);
-
-        //noinspection deprecation
-        return mContext.getResources().getDrawable(drawableId);
     }
 }

--- a/library/src/main/java/com/github/paolorotolo/appintro/ResourceUtils.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/ResourceUtils.java
@@ -1,0 +1,19 @@
+package com.github.paolorotolo.appintro;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+class ResourceUtils {
+    @Nullable
+    static Drawable getDrawable(@NonNull Context context, @DrawableRes int drawableId) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            return context.getDrawable(drawableId);
+
+        //noinspection deprecation
+        return context.getResources().getDrawable(drawableId);
+    }
+}


### PR DESCRIPTION
The function ```Resources.getDrawable(int)``` is deprecated for newer APIs. In the class **DefaultIndicatorController** there was a method to call the right function already. I moved that function into a separate class to use it in **AppIntroFragment** as well. 