### PR TITLE
Suppress deprecation warning

### DIFF
--- a/library/src/main/java/com/github/paolorotolo/appintro/ResourceUtils.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/ResourceUtils.java
@@ -9,6 +9,7 @@ import android.support.annotation.Nullable;
 
 class ResourceUtils {
     @Nullable
+    @SuppressWarnings("deprecation")
     static Drawable getDrawable(@NonNull Context context, @DrawableRes int drawableId) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
             return context.getDrawable(drawableId);


### PR DESCRIPTION
At the moment the compiler complains about the call to a deprecated function. This warning is not needed because the calling method was created because of the deprecation and handles the call to the right function.