### PR TITLE
Support for DPAD, based on reported bug for Nexus Player remote

### DIFF
--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
@@ -270,7 +270,7 @@ public abstract class AppIntro extends AppCompatActivity {
 
     @Override
     public boolean onKeyDown(int code, KeyEvent kvent) {
-        if (code == KeyEvent.KEYCODE_ENTER || code == KeyEvent.KEYCODE_BUTTON_A) {
+        if (code == KeyEvent.KEYCODE_ENTER || code == KeyEvent.KEYCODE_BUTTON_A || code == KeyEvent.KEYCODE_DPAD_CENTER) {
             ViewPager vp = (ViewPager) this.findViewById(R.id.view_pager);
             if (vp.getCurrentItem() == vp.getAdapter().getCount() - 1) {
                 onDonePressed();

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
@@ -216,7 +216,7 @@ public abstract class AppIntro2 extends AppCompatActivity {
 
     @Override
     public boolean onKeyDown(int code, KeyEvent kevent) {
-        if (code == KeyEvent.KEYCODE_ENTER || code == KeyEvent.KEYCODE_BUTTON_A) {
+        if (code == KeyEvent.KEYCODE_ENTER || code == KeyEvent.KEYCODE_BUTTON_A || KeyEvent.KEYCODE_DPAD_CENTER) {
             ViewPager vp = (ViewPager) this.findViewById(R.id.view_pager);
             if (vp.getCurrentItem() == vp.getAdapter().getCount() - 1) {
                 onDonePressed();


### PR DESCRIPTION
Android TV remotes rely on a different key than a gamepad. This allows either one to work.