### PR TITLE
Added Page Swipe Locking and more general Next/Done visibility toggle

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,15 +1,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "paolorotolo.github.com.appintroexample"
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 4
         versionName "1.2.1"
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -17,10 +19,18 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    packagingOptions {
+        exclude 'LICENSE.txt'
+    }
 }
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:appcompat-v7:23.0.1'
     compile project(':library')
+
+
+    // test dependencies
+    androidTestCompile 'com.android.support.test:runner:0.4.1'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'
 }

--- a/example/src/androidTest/java/com/github/paolorotolo/appintroexample/ApplicationTest.java
+++ b/example/src/androidTest/java/com/github/paolorotolo/appintroexample/ApplicationTest.java
@@ -1,4 +1,4 @@
-package paolorotolo.github.com.appintroexample;
+package com.github.paolorotolo.appintroexample;
 
 import android.app.Application;
 import android.test.ApplicationTestCase;

--- a/example/src/androidTest/java/com/github/paolorotolo/appintroexample/SwipeLockTest.java
+++ b/example/src/androidTest/java/com/github/paolorotolo/appintroexample/SwipeLockTest.java
@@ -1,0 +1,207 @@
+package com.github.paolorotolo.appintroexample;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v4.view.ViewPager;
+import android.view.View;
+
+import com.github.paolorotolo.appintroexample.util.ViewPagerIdlingResource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.swipeLeft;
+import static android.support.test.espresso.action.ViewActions.swipeRight;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.Visibility;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.github.paolorotolo.appintroexample.util.OrientationChangeAction.orientationLandscape;
+import static com.github.paolorotolo.appintroexample.util.OrientationChangeAction.orientationPortrait;
+import static org.hamcrest.CoreMatchers.allOf;
+
+@RunWith(AndroidJUnit4.class)
+public class SwipeLockTest {
+
+    private ViewPagerIdlingResource viewPagerIdlingResource;
+    private int viewPagerResId;
+    private int btnSkipResId;
+    private int btnNextResId;
+    private int btnDoneResId;
+
+    @Rule
+    public ActivityTestRule<DisableSwipeIntro1> mActivityRule = new ActivityTestRule(DisableSwipeIntro1.class);
+
+    @Before
+    public void registerIntentServiceIdlingResource() {
+        viewPagerResId = R.id.view_pager;
+        btnSkipResId = R.id.skip;
+        btnNextResId = R.id.next;
+        btnDoneResId = R.id.done;
+
+        View testRootView = mActivityRule.getActivity().findViewById(android.R.id.content);
+        ViewPager testViewPager = (ViewPager) testRootView.findViewById(viewPagerResId);
+
+        viewPagerIdlingResource = new ViewPagerIdlingResource(testViewPager, "ViewPager");
+        Espresso.registerIdlingResources(viewPagerIdlingResource);
+    }
+
+    @After
+    public void unregisterIntentServiceIdlingResource() {
+        if (viewPagerIdlingResource != null) {
+            Espresso.unregisterIdlingResources(viewPagerIdlingResource);
+        }
+    }
+
+    @Test
+    public void skipButtonHiding() {
+        // hide button
+        onView(allOf(withId(btnSkipResId), isDisplayed())).check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+        onView(allOf(withId(R.id.button_disable_skip), isDisplayed())).perform(click());
+        checkButtonVisibility(btnSkipResId, Visibility.INVISIBLE);
+
+        checkButtonVisibilityOnPageSwipe(viewPagerResId, btnSkipResId, Visibility.INVISIBLE);
+        checkButtonVisibilityOnRotation(btnSkipResId, Visibility.INVISIBLE);
+
+        // show button
+        onView(allOf(withId(R.id.button_disable_skip), isDisplayed())).perform(click());
+        checkButtonVisibilityOnPageSwipe(viewPagerResId, btnSkipResId, Visibility.VISIBLE);
+    }
+
+    @Test
+    public void nextButtonHiding() {
+        // hide button
+        onView(allOf(withId(btnNextResId), isDisplayed())).check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+        onView(allOf(withId(R.id.button_disable_progress), isDisplayed())).perform(click());
+        checkButtonVisibility(btnNextResId, Visibility.INVISIBLE);
+
+        checkButtonVisibilityOnPageSwipe(viewPagerResId, btnNextResId, Visibility.INVISIBLE);
+        checkButtonVisibilityOnRotation(btnNextResId, Visibility.INVISIBLE);
+
+        // show button
+        onView(allOf(withId(R.id.button_disable_progress), isDisplayed())).perform(click());
+        checkButtonVisibilityOnPageSwipe(viewPagerResId, btnNextResId, Visibility.VISIBLE);
+    }
+
+    @Test
+    public void doneButtonHiding() {
+        onView(withId(viewPagerResId)).perform(swipeLeft());
+        onView(withId(viewPagerResId)).perform(swipeLeft());
+
+        // hide button
+        onView(allOf(withId(btnDoneResId), isDisplayed())).check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+        onView(allOf(withId(R.id.button_disable_progress), isDisplayed())).perform(click());
+        checkButtonVisibility(btnDoneResId, Visibility.INVISIBLE);
+
+        checkButtonVisibilityOnPageSwipe(viewPagerResId, btnDoneResId, Visibility.INVISIBLE);
+        checkButtonVisibilityOnRotation(btnDoneResId, Visibility.INVISIBLE);
+
+        // show button
+        onView(allOf(withId(R.id.button_disable_progress), isDisplayed())).perform(click());
+        onView(allOf(withId(btnDoneResId), isDisplayed())).check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+    }
+
+    @Test
+    public void swipeLock() {
+        onView(withId(viewPagerResId)).perform(swipeLeft());
+
+        // lock, test button hidden
+        onView(allOf(withId(btnNextResId), isDisplayed())).check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+        onView(allOf(withId(R.id.button_disable_swipe), isDisplayed())).perform(click());
+        oneShotSwipeLock();
+
+        onView(withId(viewPagerResId)).perform(swipeRight());
+        onView(allOf(withId(R.id.button_disable_swipe), isDisplayed())).perform(click());
+        onView(isRoot()).perform(orientationLandscape());
+        oneShotSwipeLock();
+    }
+
+    private void oneShotSwipeLock() {
+        checkButtonVisibility(btnNextResId, Visibility.INVISIBLE);
+
+        // test swiping is locked and buttons are hidden
+        checkButtonVisibilityOnPageSwipeLeft(viewPagerResId, btnNextResId, Visibility.INVISIBLE);
+        onView(withText("Slide 2 title")).check(matches(isDisplayed()));
+        checkButtonVisibilityOnPageSwipeRight(viewPagerResId, btnNextResId, Visibility.INVISIBLE);
+        onView(withText("Slide 2 title")).check(matches(isDisplayed()));
+        checkButtonVisibility(btnNextResId, Visibility.INVISIBLE);
+
+        // test swiping is unlocked and buttons are shown
+        onView(allOf(withId(R.id.button_disable_swipe), isDisplayed())).perform(click());
+        checkButtonVisibility(btnNextResId, Visibility.VISIBLE);
+        checkButtonVisibilityOnPageSwipeRight(viewPagerResId, btnNextResId, Visibility.VISIBLE);
+        onView(withText("Slide 1 title")).check(matches(isDisplayed()));
+        checkButtonVisibilityOnPageSwipeLeft(viewPagerResId, btnNextResId, Visibility.VISIBLE);
+        checkButtonVisibilityOnPageSwipeLeft(viewPagerResId, btnDoneResId, Visibility.VISIBLE);
+        onView(withText("Slide 3 title")).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void nextPageSwipeLock() {
+        onView(withId(viewPagerResId)).perform(swipeLeft());
+
+        // lock, test button hidden
+        onView(allOf(withId(btnNextResId), isDisplayed())).check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+        onView(allOf(withId(R.id.button_disable_next_swipe), isDisplayed())).perform(click());
+        oneShotNextPageSwipeLock();
+
+        onView(allOf(withId(R.id.button_disable_next_swipe), isDisplayed())).perform(click());
+        onView(isRoot()).perform(orientationLandscape());
+        oneShotNextPageSwipeLock();
+    }
+
+    private void oneShotNextPageSwipeLock() {
+        checkButtonVisibility(btnNextResId, Visibility.INVISIBLE);
+
+        // test swiping left is locked and buttons are hidden, restored on swipe right
+        checkButtonVisibilityOnPageSwipeLeft(viewPagerResId, btnNextResId, Visibility.INVISIBLE);
+        onView(withText("Slide 2 title")).check(matches(isDisplayed()));
+        checkButtonVisibilityOnPageSwipeRight(viewPagerResId, btnNextResId, Visibility.VISIBLE);
+        checkButtonVisibilityOnPageSwipeLeft(viewPagerResId, btnNextResId, Visibility.VISIBLE);
+        onView(withText("Slide 2 title")).check(matches(isDisplayed()));
+    }
+
+    private void checkButtonVisibilityOnPageSwipe(int viewPagerResId, int btnResId, Visibility btnVisibility) {
+        // check visibility state maintained between pages, assumes > 1 pages
+        if (mActivityRule.getActivity().getPager().getCurrentItem() == mActivityRule.getActivity().getPager().getChildCount()) {
+            checkButtonVisibilityOnPageSwipeRight(viewPagerResId, btnResId, btnVisibility);
+            checkButtonVisibilityOnPageSwipeLeft(viewPagerResId, btnResId, btnVisibility);
+        } else {
+            checkButtonVisibilityOnPageSwipeLeft(viewPagerResId, btnResId, btnVisibility);
+            checkButtonVisibilityOnPageSwipeRight(viewPagerResId, btnResId, btnVisibility);
+        }
+    }
+
+    private void checkButtonVisibilityOnPageSwipeLeft(int viewPagerResId, int btnResId, Visibility btnVisibility) {
+        onView(withId(viewPagerResId)).perform(swipeLeft());
+        checkButtonVisibility(btnResId, btnVisibility);
+    }
+
+    private void checkButtonVisibilityOnPageSwipeRight(int viewPagerResId, int btnResId, Visibility btnVisibility) {
+        onView(withId(viewPagerResId)).perform(swipeRight());
+        checkButtonVisibility(btnResId, btnVisibility);
+    }
+
+    private void checkButtonVisibilityOnRotation(int btnResId, Visibility btnVisibility) {
+        checkButtonVisibility(btnResId, btnVisibility);
+
+        // check visibility state maintained between rotation
+        onView(isRoot()).perform(orientationLandscape());
+        checkButtonVisibility(btnResId, btnVisibility);
+        onView(isRoot()).perform(orientationPortrait());
+        checkButtonVisibility(btnResId, btnVisibility);
+    }
+
+    private void checkButtonVisibility(int btnResId, Visibility btnVisibility) {
+        onView(withId(btnResId)).check(matches(withEffectiveVisibility(btnVisibility)));
+    }
+}

--- a/example/src/androidTest/java/com/github/paolorotolo/appintroexample/SwipeLockTest.java
+++ b/example/src/androidTest/java/com/github/paolorotolo/appintroexample/SwipeLockTest.java
@@ -87,6 +87,14 @@ public class SwipeLockTest {
         checkButtonVisibilityOnPageSwipe(viewPagerResId, btnNextResId, Visibility.INVISIBLE);
         checkButtonVisibilityOnRotation(btnNextResId, Visibility.INVISIBLE);
 
+        // check that prior progress button visibility state is maintained when toggling swipe locking
+        onView(allOf(withId(R.id.button_disable_swipe), isDisplayed())).perform(click());
+        onView(allOf(withId(R.id.button_disable_swipe), isDisplayed())).perform(click());
+        checkButtonVisibility(btnNextResId, Visibility.INVISIBLE);
+        onView(allOf(withId(R.id.button_disable_next_swipe), isDisplayed())).perform(click());
+        onView(allOf(withId(R.id.button_disable_next_swipe), isDisplayed())).perform(click());
+        checkButtonVisibility(btnNextResId, Visibility.INVISIBLE);
+
         // show button
         onView(allOf(withId(R.id.button_disable_progress), isDisplayed())).perform(click());
         checkButtonVisibilityOnPageSwipe(viewPagerResId, btnNextResId, Visibility.VISIBLE);

--- a/example/src/androidTest/java/com/github/paolorotolo/appintroexample/util/OrientationChangeAction.java
+++ b/example/src/androidTest/java/com/github/paolorotolo/appintroexample/util/OrientationChangeAction.java
@@ -1,0 +1,80 @@
+package com.github.paolorotolo.appintroexample.util;
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - Nathan Barraille
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import android.support.test.runner.lifecycle.Stage;
+import android.view.View;
+
+import org.hamcrest.Matcher;
+
+import java.util.Collection;
+
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+
+/**
+ * An Espresso ViewAction that changes the orientation of the screen
+ */
+public class OrientationChangeAction implements ViewAction {
+    private final int orientation;
+
+    private OrientationChangeAction(int orientation) {
+        this.orientation = orientation;
+    }
+
+    @Override
+    public Matcher<View> getConstraints() {
+        return isRoot();
+    }
+
+    @Override
+    public String getDescription() {
+        return "change orientation to " + orientation;
+    }
+
+    @Override
+    public void perform(UiController uiController, View view) {
+        uiController.loopMainThreadUntilIdle();
+        final Activity activity = (Activity) view.getContext();
+        activity.setRequestedOrientation(orientation);
+
+        Collection<Activity> resumedActivities = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED);
+        if (resumedActivities.isEmpty()) {
+            throw new RuntimeException("Could not change orientation");
+        }
+    }
+
+    public static ViewAction orientationLandscape() {
+        return new OrientationChangeAction(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+    }
+
+    public static ViewAction orientationPortrait() {
+        return new OrientationChangeAction(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+    }
+}

--- a/example/src/androidTest/java/com/github/paolorotolo/appintroexample/util/OrientationChangeAction.java
+++ b/example/src/androidTest/java/com/github/paolorotolo/appintroexample/util/OrientationChangeAction.java
@@ -64,6 +64,12 @@ public class OrientationChangeAction implements ViewAction {
         final Activity activity = (Activity) view.getContext();
         activity.setRequestedOrientation(orientation);
 
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
         Collection<Activity> resumedActivities = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED);
         if (resumedActivities.isEmpty()) {
             throw new RuntimeException("Could not change orientation");

--- a/example/src/androidTest/java/com/github/paolorotolo/appintroexample/util/ViewPagerIdlingResource.java
+++ b/example/src/androidTest/java/com/github/paolorotolo/appintroexample/util/ViewPagerIdlingResource.java
@@ -1,0 +1,46 @@
+package com.github.paolorotolo.appintroexample.util;
+
+import android.support.test.espresso.IdlingResource;
+import android.support.v4.view.ViewPager;
+
+public class ViewPagerIdlingResource implements IdlingResource {
+
+    private final String mName;
+
+    private boolean mIdle = true; // Default to idle since we can't query the scroll state.
+
+    private ResourceCallback mResourceCallback;
+
+    public ViewPagerIdlingResource(ViewPager viewPager, String name) {
+        viewPager.addOnPageChangeListener(new ViewPagerListener());
+        mName = name;
+    }
+
+    @Override
+    public String getName() {
+        return mName;
+    }
+
+    @Override
+    public boolean isIdleNow() {
+        return mIdle;
+    }
+
+    @Override
+    public void registerIdleTransitionCallback(ResourceCallback resourceCallback) {
+        mResourceCallback = resourceCallback;
+    }
+
+    private class ViewPagerListener extends ViewPager.SimpleOnPageChangeListener {
+
+        @Override
+        public void onPageScrollStateChanged(int state) {
+            mIdle = (state == ViewPager.SCROLL_STATE_IDLE
+                    // Treat dragging as idle, or Espresso will block itself when swiping.
+                    || state == ViewPager.SCROLL_STATE_DRAGGING);
+            if (mIdle && mResourceCallback != null) {
+                mResourceCallback.onTransitionToIdle();
+            }
+        }
+    }
+}

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -32,8 +32,11 @@
         <activity android:name=".SecondLayoutIntro"
             android:label="@string/title_activity_second_intro"
             android:theme="@style/FullscreenTheme"/>
-        <activity android:name=".DisableSwipeIntro"
-            android:label="@string/title_activity_second_intro"
+        <activity android:name=".DisableSwipeIntro1"
+            android:label="@string/title_activity_default_intro_disable"
+            android:theme="@style/FullscreenTheme"/>
+        <activity android:name=".DisableSwipeIntro2"
+            android:label="@string/title_activity_second_intro_disable"
             android:theme="@style/FullscreenTheme"/>
         <activity android:name=".animations.CustomAnimation" />
         <activity android:name=".animations.FadeAnimation" />

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
         <activity android:name=".SecondLayoutIntro"
             android:label="@string/title_activity_second_intro"
             android:theme="@style/FullscreenTheme"/>
+        <activity android:name=".DisableSwipeIntro"
+            android:label="@string/title_activity_second_intro"
+            android:theme="@style/FullscreenTheme"/>
         <activity android:name=".animations.CustomAnimation" />
         <activity android:name=".animations.FadeAnimation" />
         <activity android:name=".animations.ZoomAnimation" />

--- a/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro.java
+++ b/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro.java
@@ -1,0 +1,30 @@
+package com.github.paolorotolo.appintroexample;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+
+import com.github.paolorotolo.appintro.AppIntro2;
+
+public class DisableSwipeIntro extends AppIntro2 {
+    @Override
+    public void init(Bundle savedInstanceState) {
+        addSlide(SampleSlide.newInstance(R.layout.intro_2));
+        addSlide(SampleSlide.newInstance(R.layout.intro2_2_disable));
+        addSlide(SampleSlide.newInstance(R.layout.intro3_2));
+    }
+
+    private void loadMainActivity(){
+        Intent intent = new Intent(this, MainActivity.class);
+        startActivity(intent);
+    }
+
+    @Override
+    public void onDonePressed() {
+        loadMainActivity();
+    }
+
+    public void getStarted(View v){
+        loadMainActivity();
+    }
+}

--- a/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro.java
+++ b/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro.java
@@ -5,16 +5,17 @@ import android.os.Bundle;
 import android.view.View;
 
 import com.github.paolorotolo.appintro.AppIntro2;
+import com.github.paolorotolo.appintro.AppIntroViewPager;
 
 public class DisableSwipeIntro extends AppIntro2 {
     @Override
     public void init(Bundle savedInstanceState) {
-        addSlide(SampleSlide.newInstance(R.layout.intro_2));
+        addSlide(SampleSlide.newInstance(R.layout.intro_2_disable));
         addSlide(SampleSlide.newInstance(R.layout.intro2_2_disable));
-        addSlide(SampleSlide.newInstance(R.layout.intro3_2));
+        addSlide(SampleSlide.newInstance(R.layout.intro3_2_disable));
     }
 
-    private void loadMainActivity(){
+    private void loadMainActivity() {
         Intent intent = new Intent(this, MainActivity.class);
         startActivity(intent);
     }
@@ -24,7 +25,27 @@ public class DisableSwipeIntro extends AppIntro2 {
         loadMainActivity();
     }
 
-    public void getStarted(View v){
+    public void getStarted(View v) {
         loadMainActivity();
+    }
+
+    public void toggleNextPageSwipeLock(View v) {
+        AppIntroViewPager pager = getPager();
+        boolean pagingState = pager.isNextPagingEnabled();
+        pagingState = !pagingState;
+        setNextPageSwipeLock(pagingState);
+    }
+
+    public void toggleSwipeLock(View v) {
+        AppIntroViewPager pager = getPager();
+        boolean pagingState = pager.isPagingEnabled();
+        pagingState = !pagingState;
+        setSwipeLock(pagingState);
+    }
+
+    public void toggleProgressButton(View v) {
+        boolean progressButtonState = isProgressButtonEnabled();
+        progressButtonState = !progressButtonState;
+        setProgressButtonEnabled(progressButtonState);
     }
 }

--- a/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro1.java
+++ b/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro1.java
@@ -11,10 +11,9 @@ import com.github.paolorotolo.appintro.AppIntroViewPager;
 public class DisableSwipeIntro1 extends AppIntro {
     @Override
     public void init(Bundle savedInstanceState) {
-        addSlide(SampleSlide.newInstance(R.layout.intro));
-        addSlide(SampleSlide.newInstance(R.layout.intro2));
+        addSlide(SampleSlide.newInstance(R.layout.intro_disable));
+        addSlide(SampleSlide.newInstance(R.layout.intro2_disable));
         addSlide(SampleSlide.newInstance(R.layout.intro3_disable));
-        addSlide(SampleSlide.newInstance(R.layout.intro4_disable));
 
     }
 

--- a/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro1.java
+++ b/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro1.java
@@ -40,14 +40,12 @@ public class DisableSwipeIntro1 extends AppIntro {
     public void toggleNextPageSwipeLock(View v) {
         AppIntroViewPager pager = getPager();
         boolean pagingState = pager.isNextPagingEnabled();
-        pagingState = !pagingState;
         setNextPageSwipeLock(pagingState);
     }
 
     public void toggleSwipeLock(View v) {
         AppIntroViewPager pager = getPager();
         boolean pagingState = pager.isPagingEnabled();
-        pagingState = !pagingState;
         setSwipeLock(pagingState);
     }
 
@@ -60,6 +58,6 @@ public class DisableSwipeIntro1 extends AppIntro {
     public void toggleSkipButton(View v) {
         boolean skipButtonState = isSkipButtonEnabled();
         skipButtonState = !skipButtonState;
-        setSkipButtonEnabled(skipButtonState);
+        showSkipButton(skipButtonState);
     }
 }

--- a/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro1.java
+++ b/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro1.java
@@ -3,21 +3,30 @@ package com.github.paolorotolo.appintroexample;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.Toast;
 
-import com.github.paolorotolo.appintro.AppIntro2;
+import com.github.paolorotolo.appintro.AppIntro;
 import com.github.paolorotolo.appintro.AppIntroViewPager;
 
-public class DisableSwipeIntro extends AppIntro2 {
+public class DisableSwipeIntro1 extends AppIntro {
     @Override
     public void init(Bundle savedInstanceState) {
-        addSlide(SampleSlide.newInstance(R.layout.intro_2_disable));
-        addSlide(SampleSlide.newInstance(R.layout.intro2_2_disable));
-        addSlide(SampleSlide.newInstance(R.layout.intro3_2_disable));
+        addSlide(SampleSlide.newInstance(R.layout.intro));
+        addSlide(SampleSlide.newInstance(R.layout.intro2));
+        addSlide(SampleSlide.newInstance(R.layout.intro3_disable));
+        addSlide(SampleSlide.newInstance(R.layout.intro4_disable));
+
     }
 
-    private void loadMainActivity() {
+    private void loadMainActivity(){
         Intent intent = new Intent(this, MainActivity.class);
         startActivity(intent);
+    }
+
+    @Override
+    public void onSkipPressed() {
+        loadMainActivity();
+        Toast.makeText(getApplicationContext(),getString(R.string.skip),Toast.LENGTH_SHORT).show();
     }
 
     @Override
@@ -25,7 +34,7 @@ public class DisableSwipeIntro extends AppIntro2 {
         loadMainActivity();
     }
 
-    public void getStarted(View v) {
+    public void getStarted(View v){
         loadMainActivity();
     }
 
@@ -47,5 +56,11 @@ public class DisableSwipeIntro extends AppIntro2 {
         boolean progressButtonState = isProgressButtonEnabled();
         progressButtonState = !progressButtonState;
         setProgressButtonEnabled(progressButtonState);
+    }
+
+    public void toggleSkipButton(View v) {
+        boolean skipButtonState = isSkipButtonEnabled();
+        skipButtonState = !skipButtonState;
+        setSkipButtonEnabled(skipButtonState);
     }
 }

--- a/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro2.java
+++ b/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro2.java
@@ -32,14 +32,12 @@ public class DisableSwipeIntro2 extends AppIntro2 {
     public void toggleNextPageSwipeLock(View v) {
         AppIntroViewPager pager = getPager();
         boolean pagingState = pager.isNextPagingEnabled();
-        pagingState = !pagingState;
         setNextPageSwipeLock(pagingState);
     }
 
     public void toggleSwipeLock(View v) {
         AppIntroViewPager pager = getPager();
         boolean pagingState = pager.isPagingEnabled();
-        pagingState = !pagingState;
         setSwipeLock(pagingState);
     }
 

--- a/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro2.java
+++ b/example/src/main/java/com/github/paolorotolo/appintroexample/DisableSwipeIntro2.java
@@ -1,0 +1,51 @@
+package com.github.paolorotolo.appintroexample;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+
+import com.github.paolorotolo.appintro.AppIntro2;
+import com.github.paolorotolo.appintro.AppIntroViewPager;
+
+public class DisableSwipeIntro2 extends AppIntro2 {
+    @Override
+    public void init(Bundle savedInstanceState) {
+        addSlide(SampleSlide.newInstance(R.layout.intro_2_disable));
+        addSlide(SampleSlide.newInstance(R.layout.intro2_2_disable));
+        addSlide(SampleSlide.newInstance(R.layout.intro3_2_disable));
+    }
+
+    private void loadMainActivity() {
+        Intent intent = new Intent(this, MainActivity.class);
+        startActivity(intent);
+    }
+
+    @Override
+    public void onDonePressed() {
+        loadMainActivity();
+    }
+
+    public void getStarted(View v) {
+        loadMainActivity();
+    }
+
+    public void toggleNextPageSwipeLock(View v) {
+        AppIntroViewPager pager = getPager();
+        boolean pagingState = pager.isNextPagingEnabled();
+        pagingState = !pagingState;
+        setNextPageSwipeLock(pagingState);
+    }
+
+    public void toggleSwipeLock(View v) {
+        AppIntroViewPager pager = getPager();
+        boolean pagingState = pager.isPagingEnabled();
+        pagingState = !pagingState;
+        setSwipeLock(pagingState);
+    }
+
+    public void toggleProgressButton(View v) {
+        boolean progressButtonState = isProgressButtonEnabled();
+        progressButtonState = !progressButtonState;
+        setProgressButtonEnabled(progressButtonState);
+    }
+}

--- a/example/src/main/java/com/github/paolorotolo/appintroexample/MainActivity.java
+++ b/example/src/main/java/com/github/paolorotolo/appintroexample/MainActivity.java
@@ -33,8 +33,13 @@ public class MainActivity extends AppCompatActivity {
         startActivity(intent);
     }
 
-    public void disableSwipeIntro(View v){
-        Intent intent = new Intent(this, DisableSwipeIntro.class);
+    public void disableSwipeIntro1(View v){
+        Intent intent = new Intent(this, DisableSwipeIntro1.class);
+        startActivity(intent);
+    }
+
+    public void disableSwipeIntro2(View v){
+        Intent intent = new Intent(this, DisableSwipeIntro2.class);
         startActivity(intent);
     }
 

--- a/example/src/main/java/com/github/paolorotolo/appintroexample/MainActivity.java
+++ b/example/src/main/java/com/github/paolorotolo/appintroexample/MainActivity.java
@@ -33,6 +33,11 @@ public class MainActivity extends AppCompatActivity {
         startActivity(intent);
     }
 
+    public void disableSwipeIntro(View v){
+        Intent intent = new Intent(this, DisableSwipeIntro.class);
+        startActivity(intent);
+    }
+
     public void startSecondLayoutIntro(View v){
         Intent intent = new Intent(this, SecondLayoutIntro.class);
         startActivity(intent);

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -37,8 +37,15 @@
                 android:layout_gravity="center"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:onClick="disableSwipeIntro"
-                android:text="@string/disable_swipe_intro"/>
+                android:onClick="disableSwipeIntro1"
+                android:text="@string/disable_swipe_intro_1"/>
+
+        <Button
+                android:layout_gravity="center"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="disableSwipeIntro2"
+                android:text="@string/disable_swipe_intro_2"/>
         <View
                 android:layout_width="fill_parent"
                 android:layout_height="0.5dp"

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -32,6 +32,13 @@
                 android:layout_height="wrap_content"
                 android:onClick="startCustomIntro"
                 android:text="@string/customized_intro"/>
+
+        <Button
+                android:layout_gravity="center"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="disableSwipeIntro"
+                android:text="@string/disable_swipe_intro"/>
         <View
                 android:layout_width="fill_parent"
                 android:layout_height="0.5dp"

--- a/example/src/main/res/layout/intro2_2_disable.xml
+++ b/example/src/main/res/layout/intro2_2_disable.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_weight="10"
+    android:background="#00BCD4"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_gravity="center"
+        android:layout_weight="2"
+        android:fontFamily="sans-serif-thin"
+        android:gravity="center"
+        android:paddingLeft="32dp"
+        android:paddingRight="32dp"
+        android:text="Slide 2 title"
+        android:textColor="#ffffff"
+        android:textSize="28sp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_gravity="center"
+        android:layout_weight="2"
+        android:gravity="center"
+        android:paddingLeft="64dp"
+        android:paddingRight="64dp"
+        android:text="Press the first button to disable swiping to the next slide, but you can still swipe back to previous slides. Swiping is re-enabled after moving to a previous slide \n\n Press the second button to disable swiping completely."
+        android:textColor="#ffffff"
+        android:textSize="16sp" />
+
+    <Button
+        android:id="@+id/button_disable_next_swipe"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="toggleNextPageSwipeLock"
+        android:text="Disable Swiping to Next Slide" />
+
+    <Button
+        android:id="@+id/button_disable_swipe"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="toggleSwipeLock"
+        android:text="Disable Swiping" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="64dp" />
+</LinearLayout>

--- a/example/src/main/res/layout/intro2_2_disable.xml
+++ b/example/src/main/res/layout/intro2_2_disable.xml
@@ -28,7 +28,7 @@
         android:gravity="center"
         android:paddingLeft="64dp"
         android:paddingRight="64dp"
-        android:text="The first button disables swiping to the next slide, but you can still swipe back to previous slides. Swiping is re-enabled after moving to a previous slide \n\n The second button disables swiping completely. \n\n The third button disables the Next/Done button, independent of locking swiping."
+        android:text="@string/disable_swiping_slide_text"
         android:textColor="#ffffff"
         android:textSize="16sp" />
 

--- a/example/src/main/res/layout/intro2_disable.xml
+++ b/example/src/main/res/layout/intro2_disable.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#4CAF50"
+    android:background="#00BCD4"
     android:layout_weight="10"
     android:id="@+id/main">
 
@@ -17,7 +17,7 @@
         android:textColor="#ffffff"
         android:paddingRight="32dp"
         android:textSize="28sp"
-        android:text="Slide 4 title"/>
+        android:text="Slide 2 title"/>
 
     <TextView
         android:layout_width="wrap_content"
@@ -62,7 +62,6 @@
         android:layout_gravity="center_horizontal"
         android:onClick="toggleSkipButton"
         android:text="Toggle Skip Button" />
-
     <TextView
         android:layout_width="fill_parent"
         android:layout_height="64dp" />

--- a/example/src/main/res/layout/intro3_2_disable.xml
+++ b/example/src/main/res/layout/intro3_2_disable.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/main"
-    android:layout_width="match_parent"
+    android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="#4CAF50"
     android:layout_weight="10"
-    android:background="#00BCD4"
-    android:orientation="vertical">
+    android:id="@+id/main">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:layout_gravity="center"
-        android:layout_weight="1"
-        android:fontFamily="sans-serif-thin"
         android:gravity="center"
         android:paddingLeft="32dp"
-        android:paddingRight="32dp"
-        android:text="Slide 2 title"
+        android:layout_weight="1"
+        android:fontFamily="sans-serif-thin"
         android:textColor="#ffffff"
-        android:textSize="28sp" />
+        android:paddingRight="32dp"
+        android:textSize="28sp"
+        android:text="Slide 3 title"/>
 
     <TextView
         android:layout_width="wrap_content"

--- a/example/src/main/res/layout/intro3_2_disable.xml
+++ b/example/src/main/res/layout/intro3_2_disable.xml
@@ -27,8 +27,7 @@
         android:gravity="center"
         android:paddingLeft="64dp"
         android:paddingRight="64dp"
-        android:text="The first button disables swiping to the next slide, but you can still swipe back to previous slides. Swiping is re-enabled after moving to a previous slide \n\n The second button disables swiping completely. \n\n The third button disables the Next/Done button, independent of locking swiping."
-        android:textColor="#ffffff"
+        android:text="@string/disable_swiping_slide_text"         android:textColor="#ffffff"
         android:textSize="16sp" />
 
     <Button

--- a/example/src/main/res/layout/intro3_disable.xml
+++ b/example/src/main/res/layout/intro3_disable.xml
@@ -16,7 +16,7 @@
         android:gravity="center"
         android:paddingLeft="32dp"
         android:paddingRight="32dp"
-        android:text="Slide 1 title"
+        android:text="Slide 3 title"
         android:textColor="#ffffff"
         android:textSize="28sp" />
 
@@ -55,6 +55,14 @@
         android:layout_gravity="center_horizontal"
         android:onClick="toggleProgressButton"
         android:text="Toggle Progress Button" />
+
+    <Button
+        android:id="@+id/button_disable_skip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="toggleSkipButton"
+        android:text="Toggle Skip Button" />
 
     <TextView
         android:layout_width="fill_parent"

--- a/example/src/main/res/layout/intro4_disable.xml
+++ b/example/src/main/res/layout/intro4_disable.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/main"
-    android:layout_width="match_parent"
+    android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="#4CAF50"
     android:layout_weight="10"
-    android:background="#5C6BC0"
-    android:orientation="vertical">
+    android:id="@+id/main">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:layout_gravity="center"
-        android:layout_weight="1"
-        android:fontFamily="sans-serif-thin"
         android:gravity="center"
         android:paddingLeft="32dp"
-        android:paddingRight="32dp"
-        android:text="Slide 1 title"
+        android:layout_weight="1"
+        android:fontFamily="sans-serif-thin"
         android:textColor="#ffffff"
-        android:textSize="28sp" />
+        android:paddingRight="32dp"
+        android:textSize="28sp"
+        android:text="Slide 4 title"/>
 
     <TextView
         android:layout_width="wrap_content"
@@ -55,6 +54,14 @@
         android:layout_gravity="center_horizontal"
         android:onClick="toggleProgressButton"
         android:text="Toggle Progress Button" />
+
+    <Button
+        android:id="@+id/button_disable_skip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="toggleSkipButton"
+        android:text="Toggle Skip Button" />
 
     <TextView
         android:layout_width="fill_parent"

--- a/example/src/main/res/layout/intro_2_disable.xml
+++ b/example/src/main/res/layout/intro_2_disable.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/main"
-    android:layout_width="match_parent"
+    android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="#5C6BC0"
     android:layout_weight="10"
-    android:background="#00BCD4"
-    android:orientation="vertical">
+    android:id="@+id/main">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:layout_gravity="center"
-        android:layout_weight="1"
-        android:fontFamily="sans-serif-thin"
         android:gravity="center"
         android:paddingLeft="32dp"
-        android:paddingRight="32dp"
-        android:text="Slide 2 title"
+        android:layout_weight="1"
+        android:fontFamily="sans-serif-thin"
         android:textColor="#ffffff"
-        android:textSize="28sp" />
+        android:paddingRight="32dp"
+        android:textSize="28sp"
+        android:text="Slide 1 title"/>
 
     <TextView
         android:layout_width="wrap_content"

--- a/example/src/main/res/layout/intro_disable.xml
+++ b/example/src/main/res/layout/intro_disable.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#222222"
+    android:layout_weight="10"
+    android:id="@+id/main">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:paddingLeft="32dp"
+        android:layout_weight="1"
+        android:fontFamily="sans-serif-thin"
+        android:textColor="#ffffff"
+        android:paddingRight="32dp"
+        android:textSize="28sp"
+        android:text="Slide 1 title"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_gravity="center"
+        android:layout_weight="3"
+        android:gravity="center"
+        android:paddingLeft="64dp"
+        android:paddingRight="64dp"
+        android:text="@string/disable_swiping_slide_text"
+        android:textColor="#ffffff"
+        android:textSize="16sp" />
+
+    <Button
+        android:id="@+id/button_disable_next_swipe"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="toggleNextPageSwipeLock"
+        android:text="Toggle Disable Swiping to Next Slide" />
+
+    <Button
+        android:id="@+id/button_disable_swipe"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="toggleSwipeLock"
+        android:text="Toggle Disable Swiping" />
+
+    <Button
+        android:id="@+id/button_disable_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="toggleProgressButton"
+        android:text="Toggle Progress Button" />
+
+    <Button
+        android:id="@+id/button_disable_skip"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="toggleSkipButton"
+        android:text="Toggle Skip Button" />
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="64dp" />
+</LinearLayout>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="hello_world">Hello world!</string>
     <string name="action_settings">Settings</string>
     <string name="customized_intro">Start custom Intro</string>
+    <string name="disable_swipe_intro">Disable swipe Intro</string>
     <string name="default_intro">Start default Intro</string>
     <string name="fade_animation">Set Fade animation</string>
     <string name="custom_animation">Set custom Transformer</string>
@@ -15,6 +16,7 @@
     <string name="title_activity_default_intro">DefaultIntro</string>
     <string name="title_activity_custom_intro">CustomIntro</string>
     <string name="title_activity_second_intro">SecondLayoutIntro</string>
+    <string name="title_activity_disable_swipe_intro">DisableSwipeIntro</string>
     <string name="skip">Y U DO DIS TO ME?</string>
     <string name="header_animations">Animations</string>
     <string name="header_indicators">Indicators</string>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -4,7 +4,8 @@
     <string name="hello_world">Hello world!</string>
     <string name="action_settings">Settings</string>
     <string name="customized_intro">Start custom Intro</string>
-    <string name="disable_swipe_intro">Disable swipe Intro</string>
+    <string name="disable_swipe_intro_1">Disable swipe</string>
+    <string name="disable_swipe_intro_2">Disable swipe Layout 2</string>
     <string name="default_intro">Start default Intro</string>
     <string name="fade_animation">Set Fade animation</string>
     <string name="custom_animation">Set custom Transformer</string>
@@ -16,6 +17,8 @@
     <string name="title_activity_default_intro">DefaultIntro</string>
     <string name="title_activity_custom_intro">CustomIntro</string>
     <string name="title_activity_second_intro">SecondLayoutIntro</string>
+    <string name="title_activity_default_intro_disable">DisableSwipeDefaultLayoutIntro</string>
+    <string name="title_activity_second_intro_disable">DisableSwipeSecondLayoutIntro</string>
     <string name="title_activity_disable_swipe_intro">DisableSwipeIntro</string>
     <string name="skip">Y U DO DIS TO ME?</string>
     <string name="header_animations">Animations</string>
@@ -24,4 +27,5 @@
     <string name="flow_animation">SET FLOW ANIMATION</string>
     <string name="depth_animation">SET DEPTH ANIMATION</string>
     <string name="slideover_animation">SET SLIDEOVER ANIMATION</string>
+    <string name="disable_swiping_slide_text">The first button disables swiping to the next slide, but you can still swipe back to previous slides. Swiping is re-enabled after moving to a previous slide \n\n The second button disables swiping completely. \n\n The third button disables the Next/Done button, independent of locking swiping.</string>
 </resources>

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
@@ -19,6 +19,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.List;
 import java.util.Vector;
@@ -216,7 +217,7 @@ public abstract class AppIntro extends AppCompatActivity {
 
     /**
      * Setting to to display or hide the Next or Done button. This is a static setting and
-     * button state is maintained on each slide until explicitly changed.
+     * button state is maintained across slides until explicitly changed.
      *
      * @param progressButtonEnabled Set true to display. False to hide.
      */
@@ -242,17 +243,6 @@ public abstract class AppIntro extends AppCompatActivity {
 
     public boolean isSkipButtonEnabled() {
         return skipButtonEnabled;
-    }
-
-    /**
-     * Setting to to display or hide the Skip button. This is a static setting and
-     * button state is maintained on each slide until explicitly changed.
-     *
-     * @param skipButtonEnabled Set true to display. False to hide.
-     */
-    public void setSkipButtonEnabled(boolean skipButtonEnabled) {
-        this.skipButtonEnabled = skipButtonEnabled;
-        setButtonState(skipButton, skipButtonEnabled);
     }
 
     private void setButtonState(View button, boolean show) {
@@ -300,9 +290,25 @@ public abstract class AppIntro extends AppCompatActivity {
 
     }
 
+    /**
+     * Setting to to display or hide the Skip button. This is a static setting and
+     * button state is maintained across slides until explicitly changed.
+     *
+     * @param showButton Set true to display. False to hide.
+     */
     public void showSkipButton(boolean showButton) {
         this.skipButtonEnabled = showButton;
         setButtonState(skipButton, showButton);
+    }
+
+    /**
+     * Shows or hides Done button, replaced with setProgressButtonEnabled
+     *
+     * @deprecated use {@link #setProgressButtonEnabled(boolean)} instead.
+     */
+    @Deprecated
+    public void showDoneButton(boolean showDone) {
+        setProgressButtonEnabled(showDone);
     }
 
     public void setVibrate(boolean vibrate) {
@@ -403,22 +409,35 @@ public abstract class AppIntro extends AppCompatActivity {
      * left occurs, the lock state is reset and swiping is re-enabled. (one shot disable) This also
      * hides/shows the Next and Done buttons accordingly.
      *
-     * @param pagingState Set true to disable forward swiping. False to enable.
+     * @param lockEnable Set true to disable forward swiping. False to enable.
      */
-    public void setNextPageSwipeLock(boolean pagingState) {
-        baseProgressButtonEnabled = progressButtonEnabled;
-        pager.setNextPagingEnabled(pagingState);
-        setProgressButtonEnabled(pagingState);
+    public void setNextPageSwipeLock(boolean lockEnable) {
+        if (lockEnable) {
+            // if locking, save current progress button visibility
+            baseProgressButtonEnabled = progressButtonEnabled;
+            setProgressButtonEnabled(!lockEnable);
+        } else {
+            // if unlocking, restore original button visibility
+            setProgressButtonEnabled(baseProgressButtonEnabled);
+        }
+        pager.setNextPagingEnabled(!lockEnable);
     }
 
     /**
      * Setting to disable swiping left and right on current page. This also
      * hides/shows the Next and Done buttons accordingly.
      *
-     * @param pagingState Set true to disable forward swiping. False to enable.
+     * @param lockEnable Set true to disable forward swiping. False to enable.
      */
-    public void setSwipeLock(boolean pagingState) {
-        pager.setPagingEnabled(pagingState);
-        setProgressButtonEnabled(pagingState);
+    public void setSwipeLock(boolean lockEnable) {
+        if (lockEnable) {
+            // if locking, save current progress button visibility
+            baseProgressButtonEnabled = progressButtonEnabled;
+            setProgressButtonEnabled(!lockEnable);
+        } else {
+            // if unlocking, restore original button visibility
+            setProgressButtonEnabled(baseProgressButtonEnabled);
+        }
+        pager.setPagingEnabled(!lockEnable);
     }
 }

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
@@ -34,8 +34,8 @@ public abstract class AppIntro2 extends AppCompatActivity {
     private boolean progressButtonEnabled = true;
     private int selectedIndicatorColor = DEFAULT_COLOR;
     private int unselectedIndicatorColor = DEFAULT_COLOR;
-    private ImageView nextButton;
-    private ImageView doneButton;
+    private View nextButton;
+    private View doneButton;
 
     static enum TransformType {
         FLOW,
@@ -55,8 +55,8 @@ public abstract class AppIntro2 extends AppCompatActivity {
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.intro_layout2);
 
-        nextButton = (ImageView) findViewById(R.id.next);
-        doneButton = (ImageView) findViewById(R.id.done);
+        nextButton = findViewById(R.id.next);
+        doneButton = findViewById(R.id.done);
         mVibrator = (Vibrator) this.getSystemService(VIBRATOR_SERVICE);
 
         nextButton.setOnClickListener(new View.OnClickListener() {
@@ -181,7 +181,7 @@ public abstract class AppIntro2 extends AppCompatActivity {
         return progressButtonEnabled;
     }
 
-    private void setButtonState(ImageView button, boolean show) {
+    private void setButtonState(View button, boolean show) {
         if (show) {
             button.setVisibility(View.VISIBLE);
         } else {

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
@@ -193,8 +193,18 @@ public abstract class AppIntro2 extends AppCompatActivity {
     }
 
     /**
+     * Shows or hides Done button, replaced with setProgressButtonEnabled
+     *
+     * @deprecated use {@link #setProgressButtonEnabled(boolean)} instead.
+     */
+    @Deprecated
+    public void showDoneButton(boolean showDone) {
+        setProgressButtonEnabled(showDone);
+    }
+
+    /**
      * Setting to to display or hide the Next or Done button. This is a static setting and
-     * button state is maintained on each slide until explicitly changed.
+     * button state is maintained across slides until explicitly changed.
      *
      * @param progressButtonEnabled Set true to display. False to hide.
      */
@@ -321,22 +331,35 @@ public abstract class AppIntro2 extends AppCompatActivity {
      * left occurs, the lock state is reset and swiping is re-enabled. (one shot disable) This also
      * hides/shows the Next and Done buttons accordingly.
      *
-     * @param pagingState Set true to disable forward swiping. False to enable.
+     * @param lockEnable Set true to disable forward swiping. False to enable.
      */
-    public void setNextPageSwipeLock(boolean pagingState) {
-        baseProgressButtonEnabled = progressButtonEnabled;
-        pager.setNextPagingEnabled(pagingState);
-        setProgressButtonEnabled(pagingState);
+    public void setNextPageSwipeLock(boolean lockEnable) {
+        if (lockEnable) {
+            // if locking, save current progress button visibility
+            baseProgressButtonEnabled = progressButtonEnabled;
+            setProgressButtonEnabled(!lockEnable);
+        } else {
+            // if unlocking, restore original button visibility
+            setProgressButtonEnabled(baseProgressButtonEnabled);
+        }
+        pager.setNextPagingEnabled(!lockEnable);
     }
 
     /**
      * Setting to disable swiping left and right on current page. This also
      * hides/shows the Next and Done buttons accordingly.
      *
-     * @param pagingState Set true to disable forward swiping. False to enable.
+     * @param lockEnable Set true to disable forward swiping. False to enable.
      */
-    public void setSwipeLock(boolean pagingState) {
-        pager.setPagingEnabled(pagingState);
-        setProgressButtonEnabled(pagingState);
+    public void setSwipeLock(boolean lockEnable) {
+        if (lockEnable) {
+            // if locking, save current progress button visibility
+            baseProgressButtonEnabled = progressButtonEnabled;
+            setProgressButtonEnabled(!lockEnable);
+        } else {
+            // if unlocking, restore original button visibility
+            setProgressButtonEnabled(baseProgressButtonEnabled);
+        }
+        pager.setPagingEnabled(!lockEnable);
     }
 }

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2.java
@@ -15,6 +15,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import java.util.List;
 import java.util.Vector;
@@ -23,7 +24,7 @@ public abstract class AppIntro2 extends AppCompatActivity {
     public final static int DEFAULT_COLOR = 1;
 
     private PagerAdapter mPagerAdapter;
-    private ViewPager pager;
+    private AppIntroViewPager pager;
     private List<Fragment> fragments = new Vector<>();
     private List<ImageView> dots;
     private int slidesNumber;
@@ -34,6 +35,7 @@ public abstract class AppIntro2 extends AppCompatActivity {
     private boolean showDone = true;
     private int selectedIndicatorColor = DEFAULT_COLOR;
     private int unselectedIndicatorColor = DEFAULT_COLOR;
+    private boolean showNext = true;
 
     static enum TransformType {
         FLOW,
@@ -78,7 +80,7 @@ public abstract class AppIntro2 extends AppCompatActivity {
         });
 
         mPagerAdapter = new PagerAdapter(super.getSupportFragmentManager(), fragments);
-        pager = (ViewPager) findViewById(R.id.view_pager);
+        pager = (AppIntroViewPager) findViewById(R.id.view_pager);
         pager.setAdapter(this.mPagerAdapter);
 
         /**
@@ -168,6 +170,17 @@ public abstract class AppIntro2 extends AppCompatActivity {
         }
     }
 
+    public void showNextButton(boolean showNext) {
+        this.showNext = showNext;
+        ImageView next = (ImageView) findViewById(R.id.next);
+
+        if (!showNext) {
+            next.setVisibility(View.INVISIBLE);
+        } else {
+            next.setVisibility(View.VISIBLE);
+        }
+    }
+
     public void setVibrate(boolean vibrate) {
         this.isVibrateOn = vibrate;
     }
@@ -226,7 +239,6 @@ public abstract class AppIntro2 extends AppCompatActivity {
 
     public abstract void onDonePressed();
 
-
     public void onDotSelected(int index) {
     }
 
@@ -255,5 +267,23 @@ public abstract class AppIntro2 extends AppCompatActivity {
             if(unselectedIndicatorColor != DEFAULT_COLOR)
                 mController.setUnselectedIndicatorColor(unselectedIndicatorColor);
         }
+
+    public void toggleNextPageSwipeLock(View v) {
+        // call this method to disable forward swiping (this is a one shot swipe disable)
+        boolean pagingState = pager.getNextPagingEnabled();
+        pagingState = !pagingState;
+        pager.setNextPagingEnabled(pagingState);
+        showNextButton(pagingState);
+        Toast.makeText(this, "nextPagingState is: " + pagingState, Toast.LENGTH_SHORT).show();
+    }
+
+    public void toggleSwipeLock(View v) {
+        // call this method to disable forward swiping (this is a one shot swipe disable)
+        boolean pagingState = pager.getPagingEnabled();
+        pagingState = !pagingState;
+        pager.setPagingEnabled(pagingState);
+        showNextButton(pagingState);
+        showDoneButton(pagingState);
+        Toast.makeText(this, "pagingState is: " + pagingState, Toast.LENGTH_SHORT).show();
     }
 }

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
@@ -1,0 +1,88 @@
+package com.github.paolorotolo.appintro;
+
+import android.content.Context;
+import android.support.v4.view.ViewPager;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+/**
+ * Created by dluong on 10/27/2015.
+ */
+class AppIntroViewPager extends ViewPager {
+
+    private boolean pagingEnabled;
+    private boolean nextPagingEnabled;
+    private float initialXValue;
+    private int lockPage;
+
+    public AppIntroViewPager(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        pagingEnabled = true;
+        nextPagingEnabled = true;
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if(!pagingEnabled){
+            return false;
+        }
+        // skip lock page logic if moved to a previous page
+        if (!nextPagingEnabled && (lockPage != getCurrentItem())) {
+            nextPagingEnabled = true;
+        }
+
+        if (!nextPagingEnabled) {
+            if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                initialXValue = event.getX();
+            }
+            if (event.getAction() == MotionEvent.ACTION_MOVE) {
+                if (detectSwipeToRight(event)) {
+                    return false;
+                }
+            }
+        }
+
+        return super.onTouchEvent(event);
+    }
+
+    // To enable/disable swipe
+    public void setNextPagingEnabled(boolean enabled) {
+        nextPagingEnabled = enabled;
+        if (!nextPagingEnabled) {
+            lockPage = getCurrentItem();
+        }
+    }
+
+    public boolean getNextPagingEnabled() {
+        return nextPagingEnabled;
+    }
+
+    // To enable/disable swipe
+    public void setPagingEnabled(boolean enabled) {
+        pagingEnabled = enabled;
+    }
+
+    public boolean getPagingEnabled() {
+        return pagingEnabled;
+    }
+
+    // Detects the direction of swipe. Right or left.
+    // Returns true if swipe is in right direction
+    private boolean detectSwipeToRight(MotionEvent event) {
+        final int SWIPE_THRESHOLD = 0; // detect swipe
+        boolean result = false;
+
+        try {
+            float diffX = event.getX() - initialXValue;
+            if (Math.abs(diffX) > SWIPE_THRESHOLD) {
+                if (diffX < 0) {
+                    // swipe from right to left detected ie.SwipeLeft
+                    result = true;
+                }
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+        return result;
+    }
+}

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
@@ -5,9 +5,6 @@ import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 
-/**
- * Created by dluong on 10/27/2015.
- */
 public class AppIntroViewPager extends ViewPager {
 
     private boolean pagingEnabled;

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
@@ -8,7 +8,7 @@ import android.view.MotionEvent;
 /**
  * Created by dluong on 10/27/2015.
  */
-class AppIntroViewPager extends ViewPager {
+public class AppIntroViewPager extends ViewPager {
 
     private boolean pagingEnabled;
     private boolean nextPagingEnabled;
@@ -26,7 +26,7 @@ class AppIntroViewPager extends ViewPager {
         if(!pagingEnabled){
             return false;
         }
-        // skip lock page logic if moved to a previous page
+        // disable lock page logic if swiped to a previous page
         if (!nextPagingEnabled && (lockPage != getCurrentItem())) {
             nextPagingEnabled = true;
         }
@@ -46,24 +46,23 @@ class AppIntroViewPager extends ViewPager {
     }
 
     // To enable/disable swipe
-    public void setNextPagingEnabled(boolean enabled) {
-        nextPagingEnabled = enabled;
+    public void setNextPagingEnabled(boolean nextPagingEnabled) {
+        this.nextPagingEnabled = nextPagingEnabled;
         if (!nextPagingEnabled) {
             lockPage = getCurrentItem();
         }
     }
 
-    public boolean getNextPagingEnabled() {
+    public boolean isNextPagingEnabled() {
         return nextPagingEnabled;
     }
 
-    // To enable/disable swipe
-    public void setPagingEnabled(boolean enabled) {
-        pagingEnabled = enabled;
+    public boolean isPagingEnabled() {
+        return pagingEnabled;
     }
 
-    public boolean getPagingEnabled() {
-        return pagingEnabled;
+    public void setPagingEnabled(boolean pagingEnabled) {
+        this.pagingEnabled = pagingEnabled;
     }
 
     // Detects the direction of swipe. Right or left.

--- a/library/src/main/java/com/github/paolorotolo/appintro/PagerAdapter.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/PagerAdapter.java
@@ -29,4 +29,6 @@ class PagerAdapter extends FragmentPagerAdapter {
     public List<Fragment> getFragments() {
         return fragments;
     }
+
+
 }

--- a/library/src/main/res/layout-v21/intro_layout.xml
+++ b/library/src/main/res/layout-v21/intro_layout.xml
@@ -3,11 +3,11 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:background="#222222">
-        <android.support.v4.view.ViewPager
+        <com.github.paolorotolo.appintro.AppIntroViewPager
             android:id="@+id/view_pager"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content">
-        </android.support.v4.view.ViewPager>
+        </com.github.paolorotolo.appintro.AppIntroViewPager>
         <LinearLayout
             android:id="@+id/bottom"
             android:background="#00000000"

--- a/library/src/main/res/layout-v21/intro_layout2.xml
+++ b/library/src/main/res/layout-v21/intro_layout2.xml
@@ -3,11 +3,11 @@
     android:layout_width="fill_parent"
     android:background="#222222"
     android:layout_height="wrap_content">
-    <android.support.v4.view.ViewPager
+    <com.github.paolorotolo.appintro.AppIntroViewPager
         android:id="@+id/view_pager"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content">
-    </android.support.v4.view.ViewPager>
+    </com.github.paolorotolo.appintro.AppIntroViewPager>
     <LinearLayout
         android:id="@+id/bottom"
         android:background="#00000000"

--- a/library/src/main/res/layout/intro_layout.xml
+++ b/library/src/main/res/layout/intro_layout.xml
@@ -3,11 +3,11 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:background="#222222">
-        <android.support.v4.view.ViewPager
+        <com.github.paolorotolo.appintro.AppIntroViewPager
             android:id="@+id/view_pager"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content">
-        </android.support.v4.view.ViewPager>
+        </com.github.paolorotolo.appintro.AppIntroViewPager>
         <LinearLayout
             android:id="@+id/bottom"
             android:background="#00000000"

--- a/library/src/main/res/layout/intro_layout2.xml
+++ b/library/src/main/res/layout/intro_layout2.xml
@@ -3,11 +3,11 @@
     android:layout_width="fill_parent"
     android:background="#222222"
     android:layout_height="wrap_content">
-    <android.support.v4.view.ViewPager
+    <com.github.paolorotolo.appintro.AppIntroViewPager
         android:id="@+id/view_pager"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content">
-    </android.support.v4.view.ViewPager>
+    </com.github.paolorotolo.appintro.AppIntroViewPager>
     <LinearLayout
         android:id="@+id/bottom"
         android:background="#00000000"


### PR DESCRIPTION
This pull request adds the following:
1. setNextPageSwipeLock: set true to prevent user from swiping to next page only, swiping to previous pages are still allowed, and once a previous page is swiped to, the lock is disabled (to be set/cleared by user in onDotSelected or upon user defined event). Also hides/unhides next/done button accordingly.
2. setSwipeLock: set true to disable swiping to previous and next page, remains locked until set to false. Also hides next/done button accordingly.
3. setProgressButtonEnabled: set true to show next/done button on any page, set false to hide.
4. setSkipButtonEnabled: set true to show skip button on any page, set false to hide.

Example usages are added to the example application. Page lock state is maintained through configuration changes, but onKeyDown support is not implemented.

