### PR TITLE
Fix not fully rendered ripple effect

### DIFF
--- a/library/src/main/res/layout-v21/intro_layout.xml
+++ b/library/src/main/res/layout-v21/intro_layout.xml
@@ -2,7 +2,9 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:background="#222222">
+    android:background="#222222"
+    android:clipChildren="false"
+    android:clipToPadding="false">
 
     <com.github.paolorotolo.appintro.AppIntroViewPager
         android:id="@+id/view_pager"
@@ -16,7 +18,9 @@
         android:layout_alignParentBottom="true"
         android:background="#00000000"
         android:gravity="bottom"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:clipChildren="false"
+        android:clipToPadding="false">
 
         <TextView
             android:id="@+id/bottom_separator"
@@ -27,7 +31,9 @@
         <FrameLayout
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:background="#00000000">
+            android:background="#00000000"
+            android:clipChildren="false"
+            android:clipToPadding="false">
 
             <FrameLayout
                 android:id="@+id/indicator_container"

--- a/library/src/main/res/layout-v21/intro_layout2.xml
+++ b/library/src/main/res/layout-v21/intro_layout2.xml
@@ -2,7 +2,9 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:background="#222222">
+    android:background="#222222"
+    android:clipChildren="false"
+    android:clipToPadding="false">
     <FrameLayout
         android:layout_width="match_parent"
         android:id="@+id/background"
@@ -19,7 +21,9 @@
         android:layout_alignParentBottom="true"
         android:background="#00000000"
         android:gravity="bottom"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:clipChildren="false"
+        android:clipToPadding="false">
 
         <TextView
             android:id="@+id/bottom_separator"
@@ -32,7 +36,9 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
-            android:background="#00000000">
+            android:background="#00000000"
+            android:clipChildren="false"
+            android:clipToPadding="false">
 
             <FrameLayout
                 android:id="@+id/indicator_container"

--- a/library/src/main/res/layout/intro_layout.xml
+++ b/library/src/main/res/layout/intro_layout.xml
@@ -2,7 +2,9 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:background="#222222">
+    android:background="#222222"
+    android:clipChildren="false"
+    android:clipToPadding="false">
         <com.github.paolorotolo.appintro.AppIntroViewPager
             android:id="@+id/view_pager"
             android:layout_width="fill_parent"
@@ -15,7 +17,9 @@
             android:layout_height="64dp"
             android:gravity="bottom"
             android:layout_alignParentBottom="true"
-            android:orientation="vertical" >
+            android:orientation="vertical" 
+            android:clipChildren="false"
+    		android:clipToPadding="false">
             <TextView
                 android:layout_width="fill_parent"
                 android:id="@+id/bottom_separator"
@@ -26,7 +30,9 @@
             <FrameLayout
                 android:background="#00000000"
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent">
+                android:layout_height="fill_parent"
+                android:clipChildren="false"
+    			android:clipToPadding="false">
 
                 <FrameLayout
                     android:id="@+id/indicator_container"

--- a/library/src/main/res/layout/intro_layout2.xml
+++ b/library/src/main/res/layout/intro_layout2.xml
@@ -2,7 +2,9 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:background="#222222"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:clipChildren="false"
+    android:clipToPadding="false">
     <FrameLayout
         android:layout_width="match_parent"
         android:id="@+id/background"
@@ -19,7 +21,9 @@
         android:layout_height="80dp"
         android:gravity="bottom"
         android:layout_alignParentBottom="true"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:clipChildren="false"
+        android:clipToPadding="false">
         <TextView
             android:layout_width="fill_parent"
             android:id="@+id/bottom_separator"
@@ -31,7 +35,9 @@
             android:background="#00000000"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp">
+            android:layout_marginBottom="16dp"
+            android:clipChildren="false"
+            android:clipToPadding="false">
 
             <FrameLayout
                 android:id="@+id/indicator_container"


### PR DESCRIPTION
The ripple effect on buttons has not been fully visible (see
http://imgur.com/HTJFdFC). The fix solves the issue by adding
clipChildern and clipToPadding attributes to all parents’ layouts (see
http://goo.gl/oqbCiu for more information)