### PR TITLE
Gradle Version: Go back to stable version/Import fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro.java
@@ -19,6 +19,7 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
+import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;


### PR DESCRIPTION
Going back to stable gradle plugin version prevents annoying warnings when using an outdated pre-release.

Inludes #199.