### PR TITLE
Support for long descriptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/library/src/main/res/layout/fragment_intro_content.xml
+++ b/library/src/main/res/layout/fragment_intro_content.xml
@@ -31,15 +31,24 @@
             android:paddingRight="16dp"/>
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/description"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="fill_parent"
         android:layout_height="0dp"
-        android:layout_gravity="center"
         android:layout_weight="3"
-        android:gravity="center"
-        android:paddingLeft="64dp"
-        android:paddingRight="64dp"
-        android:textColor="@android:color/white"
-        android:textSize="16sp"/>
+        android:gravity="center_horizontal"
+        android:orientation="horizontal"
+        android:weightSum="1">
+
+        <TextView
+            android:id="@+id/description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_weight="0.9"
+            android:gravity="center"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"/>
+
+    </LinearLayout>
+
 </merge>


### PR DESCRIPTION
This PR improves the base fragment intro layout to add support for longer descriptions.

Before:
![screenshot_20160528-000253](https://cloud.githubusercontent.com/assets/631739/15623151/b0a01b06-2468-11e6-85fa-a05c98e7f7fa.png)

After:
*HDPI*
![screenshot_20160528-000331](https://cloud.githubusercontent.com/assets/631739/15623154/bf7ad8b4-2468-11e6-9c58-8d282b9f6ae2.png)

*XXHDPI*
![baconmmb29xsandromachado05282016000617](https://cloud.githubusercontent.com/assets/631739/15623160/cbc7cea6-2468-11e6-904b-50e670cb33b2.png)

