### PR TITLE
Use @colorInt annotation

### DIFF
--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2Fragment.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntro2Fragment.java
@@ -4,11 +4,11 @@ package com.github.paolorotolo.appintro;
 import android.os.Bundle;
 
 public final class AppIntro2Fragment extends AppIntroBaseFragment {
-    public static AppIntroFragment newInstance(CharSequence title, CharSequence description, int imageDrawable, int bgColor) {
+    public static AppIntroFragment newInstance(CharSequence title, CharSequence description, int imageDrawable, @ColorInt int bgColor) {
         return newInstance(title, description, imageDrawable, bgColor, 0, 0);
     }
 
-    public static AppIntroFragment newInstance(CharSequence title, CharSequence description, int imageDrawable, int bgColor, int titleColor, int descColor) {
+    public static AppIntroFragment newInstance(CharSequence title, CharSequence description, int imageDrawable, @ColorInt int bgColor, @ColorInt int titleColor, @ColorInt int descColor) {
         AppIntroFragment slide = new AppIntroFragment();
         Bundle args = new Bundle();
         args.putString(ARG_TITLE, title.toString());

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntroFragment.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntroFragment.java
@@ -14,11 +14,11 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 public final class AppIntroFragment extends AppIntroBaseFragment {
-    public static AppIntroFragment newInstance(CharSequence title, CharSequence description, int imageDrawable, int bgColor) {
+    public static AppIntroFragment newInstance(CharSequence title, CharSequence description, int imageDrawable, @ColorInt int bgColor) {
         return newInstance(title, description, imageDrawable, bgColor, 0, 0);
     }
 
-    public static AppIntroFragment newInstance(CharSequence title, CharSequence description, int imageDrawable, int bgColor, int titleColor, int descColor) {
+    public static AppIntroFragment newInstance(CharSequence title, CharSequence description, int imageDrawable, @ColorInt int bgColor, @ColorInt int titleColor, @ColorInt int descColor) {
         AppIntroFragment slide = new AppIntroFragment();
         Bundle args = new Bundle();
         args.putString(ARG_TITLE, title.toString());


### PR DESCRIPTION
The first time I used the library, I used colors like `R.color.primary` by mistake and the intro screen didn't behave as I expected as it expects a color integer 0-255.

Adding the @colorInt annonation warns users doing the same mistake directly in Android Studio.