### PR TITLE
Addressing issue #318

### DIFF
--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntroBaseFragment.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntroBaseFragment.java
@@ -86,7 +86,7 @@ public abstract class AppIntroBaseFragment extends Fragment implements ISlideSel
         if (titleColor != 0) {
             t.setTextColor(titleColor);
         }
-        if (titleTypeface != null && titleTypeface.equals("")) {
+        if (titleTypeface != null) {
             if (CustomFontCache.get(titleTypeface, getContext()) != null) {
                 t.setTypeface(CustomFontCache.get(titleTypeface, getContext()));
             }
@@ -95,7 +95,7 @@ public abstract class AppIntroBaseFragment extends Fragment implements ISlideSel
         if (descColor != 0) {
             d.setTextColor(descColor);
         }
-        if (descTypeface != null && descTypeface.equals("")) {
+        if (descTypeface != null) {
             if (CustomFontCache.get(descTypeface, getContext()) != null) {
                 d.setTypeface(CustomFontCache.get(descTypeface, getContext()));
             }

--- a/library/src/main/java/com/github/paolorotolo/appintro/CustomFontCache.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/CustomFontCache.java
@@ -28,7 +28,11 @@ public class CustomFontCache {
 
                 return tf;
             } catch (Exception e) {
-                LogHelper.w(TAG, e.toString());
+                if (tfn.equals("")){
+                    LogHelper.w(TAG, e.toString()+", Given path was empty");
+                }else {
+                    LogHelper.w(TAG, e.toString()+", Given path was: "+tfn);
+                }
                 return null;
             }
         } else {

--- a/library/src/main/java/com/github/paolorotolo/appintro/CustomFontCache.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/CustomFontCache.java
@@ -31,7 +31,8 @@ public class CustomFontCache {
                 if (tfn.equals("")){
                     LogHelper.w(TAG, e, "Empty path");
                 }else {
-                    LogHelper.w(TAG, e, tfn);                }
+                    LogHelper.w(TAG, e, tfn);
+                }
                 return null;
             }
         } else {

--- a/library/src/main/java/com/github/paolorotolo/appintro/CustomFontCache.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/CustomFontCache.java
@@ -29,10 +29,9 @@ public class CustomFontCache {
                 return tf;
             } catch (Exception e) {
                 if (tfn.equals("")){
-                    LogHelper.w(TAG, e.toString()+", Given path was empty");
+                    LogHelper.w(TAG, e, "Empty path");
                 }else {
-                    LogHelper.w(TAG, e.toString()+", Given path was: "+tfn);
-                }
+                    LogHelper.w(TAG, e, tfn);                }
                 return null;
             }
         } else {


### PR DESCRIPTION
This pull request is addressing following issue
The custom typeface is not being set when we use 
````
addSlide(AppIntroFragment.newInstance("Setup Panel","OpenSans-Light.ttf", "Lets go through the setup step by step","OpenSans-Regular.ttf" ,R.mipmap.ic_launcher, Color.parseColor("#3F51B5")));
````
Cause:-
AppIntroBaseFragment.java:89
````
....
if (titleTypeface != null && titleTypeface.equals("")) {
....
````
& 
AppIntroBaseFragment.java:98
````
....
if (descTypeface != null && descTypeface.equals("")) {
....
````
`titleTypeface.equals("")` & `descTypeface.equals("")` causes the condition to get false if we pass a non-empty valid string as a path. The empty string check is transferred to `CustomFontCache` class with appropriate log message.

If there are any issues let me know. The code is pull request is tested already

Thanks