### PR TITLE
Update AppIntroViewPager.java

### DIFF
--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
@@ -3,6 +3,7 @@ package com.github.paolorotolo.appintro;
 import android.content.Context;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.view.animation.Interpolator;
 
@@ -91,8 +92,7 @@ public final class AppIntroViewPager extends ViewPager {
         if (event.getAction() == MotionEvent.ACTION_DOWN) {
             currentTouchDownX = event.getX();
             return super.onInterceptTouchEvent(event);
-        } else if (checkPagingState(event) || checkCanRequestNextPage(event)) {
-            // Call callback method if threshold has been reached
+        } else if (checkPagingState(event) && checkCanRequestNextPage(event)) {
             checkIllegallyRequestedNextPage(event);
             return false;
         }
@@ -107,7 +107,7 @@ public final class AppIntroViewPager extends ViewPager {
             return super.onTouchEvent(event);
         }
         // Check if we should handle the touch event
-        else if (checkPagingState(event) || checkCanRequestNextPage(event)) {
+        else if (checkPagingState(event) && checkCanRequestNextPage(event)) {
             // Call callback method if threshold has been reached
             checkIllegallyRequestedNextPage(event);
             return false;
@@ -121,7 +121,7 @@ public final class AppIntroViewPager extends ViewPager {
             return true;
         }
 
-        if (!nextPagingEnabled) {
+        if (nextPagingEnabled) {
             if (event.getAction() == MotionEvent.ACTION_DOWN) {
                 currentTouchDownX = event.getX();
             }
@@ -140,7 +140,7 @@ public final class AppIntroViewPager extends ViewPager {
     }
 
     private void checkIllegallyRequestedNextPage(MotionEvent event) {
-        int swipeThreshold = 25;
+        int swipeThreshold = 50;
 
         if (event.getAction() == MotionEvent.ACTION_MOVE &&
                 Math.abs(event.getX() - currentTouchDownX) >= swipeThreshold) {
@@ -177,13 +177,13 @@ public final class AppIntroViewPager extends ViewPager {
     // Detects the direction of swipe. Right or left.
     // Returns true if swipe is in right direction
     private boolean detectSwipeToEnd(MotionEvent event) {
-        final int SWIPE_THRESHOLD = 0; // detect swipe
+        final int SWIPE_THRESHOLD = 50; // detect swipe
         boolean result = false;
 
         try {
             float diffX = event.getX() - currentTouchDownX;
             if (Math.abs(diffX) > SWIPE_THRESHOLD) {
-                if (diffX < 0) {
+                if (diffX < 0) {                    
                     // swipe from right to left detected ie.SwipeLeft
                     result = true;
                 }


### PR DESCRIPTION
This PR fixes the "swiping back" issue that many users have complained about.
Users should now be able to swipe to previous pages even when `isPolicyRespected `returns false.

Moreover, `isPolicyRespcted` is now not called every "touch", but every "swipe" detected as it should.