### PR TITLE
Fixing missing Content Description (#624)

### DIFF
--- a/appintro/src/main/res/layout/appintro_fragment_intro_content.xml
+++ b/appintro/src/main/res/layout/appintro_fragment_intro_content.xml
@@ -28,9 +28,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
+            android:contentDescription="@string/app_intro_image_content_description"
             android:paddingLeft="16dp"
-            android:paddingRight="16dp"
-            tools:ignore="ContentDescription" />
+            android:paddingRight="16dp"/>
     </LinearLayout>
 
     <LinearLayout

--- a/appintro/src/main/res/layout/appintro_intro_layout.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout.xml
@@ -62,8 +62,8 @@
                 android:layout_marginStart="8dp"
                 android:minWidth="100dp"
                 android:visibility="invisible"
-                app:srcCompat="@drawable/ic_appintro_navigate_before_white"
-                tools:ignore="ContentDescription" />
+                android:contentDescription="@string/app_intro_back_button"
+                app:srcCompat="@drawable/ic_appintro_navigate_before_white" />
 
             <ImageButton
                 android:id="@+id/next"
@@ -74,8 +74,8 @@
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
                 android:minWidth="100dp"
-                app:srcCompat="@drawable/ic_appintro_navigate_next_white"
-                tools:ignore="ContentDescription" />
+                android:contentDescription="@string/app_intro_next_button"
+                app:srcCompat="@drawable/ic_appintro_navigate_next_white" />
 
             <Button
                 android:id="@+id/done"

--- a/appintro/src/main/res/layout/appintro_intro_layout2.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout2.xml
@@ -54,8 +54,7 @@
                 android:layout_marginLeft="16dp"
                 android:layout_marginStart="16dp"
                 android:contentDescription="@string/app_intro_skip_button"
-                app:srcCompat="@drawable/ic_appintro_skip_white"
-                tools:ignore="ContentDescription" />
+                app:srcCompat="@drawable/ic_appintro_skip_white" />
 
             <ImageButton
                 android:id="@+id/back"
@@ -67,8 +66,7 @@
                 android:layout_marginStart="16dp"
                 android:visibility="invisible"
                 android:contentDescription="@string/app_intro_back_button"
-                app:srcCompat="@drawable/ic_appintro_arrow_back_white"
-                tools:ignore="ContentDescription" />
+                app:srcCompat="@drawable/ic_appintro_arrow_back_white" />
 
             <ImageButton
                 android:id="@+id/next"
@@ -79,8 +77,7 @@
                 android:layout_marginEnd="16dp"
                 android:layout_marginRight="16dp"
                 android:contentDescription="@string/app_intro_next_button"
-                app:srcCompat="@drawable/ic_appintro_arrow_forward_white"
-                tools:ignore="ContentDescription" />
+                app:srcCompat="@drawable/ic_appintro_arrow_forward_white" />
 
             <ImageButton
                 android:id="@+id/done"
@@ -92,8 +89,7 @@
                 android:layout_marginRight="16dp"
                 android:visibility="gone"
                 android:contentDescription="@string/app_intro_done_button"
-                app:srcCompat="@drawable/ic_appintro_done_white"
-                tools:ignore="ContentDescription" />
+                app:srcCompat="@drawable/ic_appintro_done_white" />
         </FrameLayout>
     </LinearLayout>
 </RelativeLayout>

--- a/appintro/src/main/res/values-it/strings.xml
+++ b/appintro/src/main/res/values-it/strings.xml
@@ -4,4 +4,5 @@
     <string name="app_intro_next_button">AVANTI</string>
     <string name="app_intro_back_button">INDIETRO</string>
     <string name="app_intro_done_button">FINE</string>
+    <string name="app_intro_image_content_description">grafica</string>
 </resources>

--- a/appintro/src/main/res/values/strings.xml
+++ b/appintro/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="app_intro_next_button" tools:ignore="MissingTranslation">NEXT</string>
     <string name="app_intro_back_button" tools:ignore="MissingTranslation">BACK</string>
     <string name="app_intro_done_button">DONE</string>
+    <string name="app_intro_image_content_description" tools:ignore="MissingTranslation">graphics</string>
 </resources>


### PR DESCRIPTION
I'm updating all the `contentDescription` attributes for the required images/imagebuttons.
Moreover I've added a new string to support the content description of the graphics. This is not translated atm, but will default to _graphics_ for the missing translation.