### PR TITLE
Corrected GitHub naming according to Brand Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ To get a deeper overview of the breaking changes, please read the [migration doc
 
 ### Library Internals ⚙️
 
-* [#774] Move from Travis to Github Actions
+* [#774] Move from Travis to GitHub Actions
 * [#768] Refactor Transformers to use a sealed class
 * [#766] Add missing @Res annotations
 * [#765] Remove `I` prefix from interface names

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ You can find a full working example of `SlidePolicy` in the [example app - Custo
 
 AppIntro comes with a **sample app** full of examples and use case that you can use as inspiration for your project. You can find it inside the [/example folder](https://github.com/AppIntro/AppIntro/tree/master/example).
 
-You can get a **debug APK** of the sample app from the **Pre Merge** Github Actions job as an [output artifact here](https://github.com/AppIntro/AppIntro/actions?query=workflow%3A%22Pre+Merge+Checks%22).
+You can get a **debug APK** of the sample app from the **Pre Merge** GitHub Actions job as an [output artifact here](https://github.com/AppIntro/AppIntro/actions?query=workflow%3A%22Pre+Merge+Checks%22).
 
 <p align="center">
     <img src="assets/sample-app.png" alt="appintro sample app" width="40%"/>
@@ -513,7 +513,7 @@ We're offering support for AppIntro on the [#appintro channel on KotlinLang Slac
 
 ### Maintainers
 
-AppIntro is currently developed and maintained by the [AppIntro Github Org](https://github.com/AppIntro). When submitting a new PR, please ping one of:
+AppIntro is currently developed and maintained by the [AppIntro GitHub Org](https://github.com/AppIntro). When submitting a new PR, please ping one of:
 
 - [@paolorotolo](https://github.com/paolorotolo)
 - [@cortinico](https://github.com/cortinico)

--- a/docs/migrating-from-5.0.md
+++ b/docs/migrating-from-5.0.md
@@ -14,7 +14,7 @@ this document might not completely cover your scenario.
 ## Package Change
 
 With the release of AppIntro 6.x we decided to updated the **project
-package** to reflect the coordinates of the Github Repo.
+package** to reflect the coordinates of the GitHub Repo.
 
 The package has been updated from:
 


### PR DESCRIPTION
[GitHub Brand Guide](https://brand.github.com/brand/names)