### PR TITLE
Add support for spannable text in SliderPage (Closes #1125)

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
@@ -66,8 +66,8 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
     final override var defaultBackgroundColorRes: Int = 0
         private set
 
-    private var title: String? = null
-    private var description: String? = null
+    private var title: CharSequence? = null
+    private var description: CharSequence? = null
     private var titleTypeface: TypefaceContainer? = null
     private var descTypeface: TypefaceContainer? = null
 
@@ -78,8 +78,8 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
         val args = arguments
         if (args != null && args.size() != 0) {
             drawable = args.getInt(ARG_DRAWABLE)
-            title = args.getString(ARG_TITLE)
-            description = args.getString(ARG_DESC)
+            title = args.getCharSequence(ARG_TITLE)
+            description = args.getCharSequence(ARG_DESC)
             bgDrawable = args.getInt(ARG_BG_DRAWABLE)
 
             val argsTitleTypeface = args.getString(ARG_TITLE_TYPEFACE)
@@ -104,8 +104,8 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
 
         if (savedInstanceState != null) {
             drawable = savedInstanceState.getInt(ARG_DRAWABLE)
-            title = savedInstanceState.getString(ARG_TITLE)
-            description = savedInstanceState.getString(ARG_DESC)
+            title = savedInstanceState.getCharSequence(ARG_TITLE)
+            description = savedInstanceState.getCharSequence(ARG_DESC)
 
             titleTypeface = TypefaceContainer(
                 savedInstanceState.getString(ARG_TITLE_TYPEFACE),
@@ -198,8 +198,8 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putInt(ARG_DRAWABLE, drawable)
         outState.putInt(ARG_BG_DRAWABLE, bgDrawable)
-        outState.putString(ARG_TITLE, title)
-        outState.putString(ARG_DESC, description)
+        outState.putCharSequence(ARG_TITLE, title)
+        outState.putCharSequence(ARG_DESC, description)
         @Suppress("DEPRECATION")
         outState.putInt(ARG_BG_COLOR, defaultBackgroundColor)
         outState.putInt(ARG_BG_COLOR_RES, defaultBackgroundColorRes)

--- a/appintro/src/main/java/com/github/appintro/model/SliderPage.kt
+++ b/appintro/src/main/java/com/github/appintro/model/SliderPage.kt
@@ -60,8 +60,8 @@ data class SliderPage @JvmOverloads constructor(
     var descriptionTypeface: String? = null,
     @DrawableRes var backgroundDrawable: Int = 0
 ) {
-    val titleString: String? get() = title?.toString()
-    val descriptionString: String? get() = description?.toString()
+    val titleString: CharSequence? get() = title
+    val descriptionString: CharSequence? get() = description
 
     /**
      * Util method to convert a [SliderPage] into an Android [Bundle].
@@ -70,12 +70,12 @@ data class SliderPage @JvmOverloads constructor(
     @Suppress("DEPRECATION")
     fun toBundle(): Bundle {
         val newBundle = Bundle()
-        newBundle.putString(ARG_TITLE, this.titleString)
+        newBundle.putCharSequence(ARG_TITLE, this.titleString)
         newBundle.putString(ARG_TITLE_TYPEFACE, this.titleTypeface)
         newBundle.putInt(ARG_TITLE_TYPEFACE_RES, this.titleTypefaceFontRes)
         newBundle.putInt(ARG_TITLE_COLOR, this.titleColor)
         newBundle.putInt(ARG_TITLE_COLOR_RES, this.titleColorRes)
-        newBundle.putString(ARG_DESC, this.descriptionString)
+        newBundle.putCharSequence(ARG_DESC, this.descriptionString)
         newBundle.putString(ARG_DESC_TYPEFACE, this.descriptionTypeface)
         newBundle.putInt(ARG_DESC_TYPEFACE_RES, this.descriptionTypefaceFontRes)
         newBundle.putInt(ARG_DESC_COLOR, this.descriptionColor)


### PR DESCRIPTION
This PR ensures `CharSequence` interface is used internally for Title and Description in AppIntroFragment to avoid breaking Spannable support.