### PR TITLE
Feature/edge to edge support

### DIFF
--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -10,6 +10,7 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import android.widget.FrameLayout
 import android.widget.ImageButton
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.ColorInt
@@ -20,9 +21,12 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.TooltipCompat.setTooltipText
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.widget.ViewPager2
 import com.github.appintro.indicator.DotIndicatorController
@@ -395,7 +399,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         indicatorController = DotIndicatorController(this)
 
         // We default to don't show the Status Bar. User can override this.
-        showStatusBar(false)
+        showStatusBar(true)
 
         setContentView(layoutId)
 
@@ -440,6 +444,17 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         pagerController.setAdapter(this.pagerAdapter)
         pagerController.registerOnPageChangeCallback(OnPageChangeCallback())
         pagerController.onNextPageRequestedListener = this
+
+        val contentView = findViewById<FrameLayout>(R.id.bottom)
+        ViewCompat.setOnApplyWindowInsetsListener(contentView) { view, insets ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                leftMargin = bars.left
+                rightMargin = bars.right
+                bottomMargin = bars.bottom
+            }
+            insets
+        }
     }
 
     override fun onPostCreate(savedInstanceState: Bundle?) {

--- a/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBase.kt
@@ -399,7 +399,7 @@ abstract class AppIntroBase : AppCompatActivity(), AppIntroViewPagerListener {
         indicatorController = DotIndicatorController(this)
 
         // We default to don't show the Status Bar. User can override this.
-        showStatusBar(true)
+        showStatusBar(false)
 
         setContentView(layoutId)
 

--- a/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
@@ -12,7 +12,6 @@ import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.LayoutRes
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat

--- a/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
+++ b/appintro/src/main/java/com/github/appintro/AppIntroBaseFragment.kt
@@ -6,6 +6,7 @@ import android.text.method.ScrollingMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.ColorInt
@@ -13,6 +14,9 @@ import androidx.annotation.ColorRes
 import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.github.appintro.internal.LogHelper
@@ -92,7 +96,7 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
         val titleText = view.findViewById<TextView>(R.id.title)
         val descriptionText = view.findViewById<TextView>(R.id.description)
         val slideImage = view.findViewById<ImageView>(R.id.image)
-        val mainLayout = view.findViewById<ConstraintLayout>(R.id.main)
+        val mainLayout = view.findViewById<FrameLayout>(R.id.main)
 
         titleText.text = viewModel.title
         descriptionText.text = viewModel.description
@@ -147,6 +151,17 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
         titleText.movementMethod = ScrollingMovementMethod()
         descriptionText.movementMethod = ScrollingMovementMethod()
 
+        ViewCompat.setOnApplyWindowInsetsListener(view.findViewById(R.id.intro_container)) { view, insets ->
+            val statusBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            (view as? ViewGroup)?.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = statusBars.top
+                bottomMargin = statusBars.bottom
+                leftMargin = statusBars.left
+                rightMargin = statusBars.right
+            }
+            insets
+        }
+
         return view
     }
 
@@ -181,6 +196,6 @@ abstract class AppIntroBaseFragment : Fragment(), SlideSelectionListener, SlideB
     override fun setBackgroundColor(
         @ColorInt backgroundColor: Int,
     ) {
-        view?.findViewById<ConstraintLayout>(R.id.main)?.setBackgroundColor(backgroundColor)
+        view?.findViewById<FrameLayout>(R.id.main)?.setBackgroundColor(backgroundColor)
     }
 }

--- a/appintro/src/main/res/layout-land/appintro_fragment_intro.xml
+++ b/appintro/src/main/res/layout-land/appintro_fragment_intro.xml
@@ -1,59 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="@dimen/appintro_statusbar_height"
-    android:paddingBottom="@dimen/appintro2_bottombar_height"
     tools:background="@color/appintro_background_color">
 
-    <TextView
-        android:id="@+id/title"
-        style="@style/AppIntroDefaultHeading"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toTopOf="@+id/description"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/midline"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="spread"
-        app:layout_constraintVertical_weight="2"
-        tools:text="Welcome" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/intro_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingTop="@dimen/appintro_statusbar_height"
+        android:paddingBottom="@dimen/appintro2_bottombar_height">
 
-    <ImageView
-        android:id="@+id/image"
-        style="@style/AppIntroDefaultImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/app_intro_image_content_description"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/midline"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        <TextView
+            android:id="@+id/title"
+            style="@style/AppIntroDefaultHeading"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintBottom_toTopOf="@+id/description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/midline"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="spread"
+            app:layout_constraintVertical_weight="2"
+            tools:text="Welcome" />
 
-    <TextView
-        android:id="@+id/description"
-        style="@style/AppIntroDefaultText"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:autoLink="web"
-        android:scrollbars="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/midline"
-        app:layout_constraintTop_toBottomOf="@+id/title"
-        app:layout_constraintVertical_chainStyle="spread"
-        app:layout_constraintVertical_weight="3"
-        tools:text="This is a demo of the AppIntro Library" />
+        <ImageView
+            android:id="@+id/image"
+            style="@style/AppIntroDefaultImage"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:contentDescription="@string/app_intro_image_content_description"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/midline"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/midline"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.5" />
+        <TextView
+            android:id="@+id/description"
+            style="@style/AppIntroDefaultText"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:autoLink="web"
+            android:scrollbars="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/midline"
+            app:layout_constraintTop_toBottomOf="@+id/title"
+            app:layout_constraintVertical_chainStyle="spread"
+            app:layout_constraintVertical_weight="3"
+            tools:text="This is a demo of the AppIntro Library" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/midline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.5" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</FrameLayout>

--- a/appintro/src/main/res/layout/appintro_fragment_intro.xml
+++ b/appintro/src/main/res/layout/appintro_fragment_intro.xml
@@ -1,51 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="@dimen/appintro_statusbar_height"
-    android:paddingBottom="@dimen/appintro2_bottombar_height"
     tools:background="@color/appintro_background_color">
 
-    <TextView
-        android:id="@+id/title"
-        style="@style/AppIntroDefaultHeading"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        app:layout_constraintBottom_toTopOf="@+id/image"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="spread"
-        app:layout_constraintVertical_weight="2"
-        tools:text="Welcome" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/intro_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingTop="@dimen/appintro_statusbar_height"
+        android:paddingBottom="@dimen/appintro2_bottombar_height">
 
-    <ImageView
-        android:id="@+id/image"
-        style="@style/AppIntroDefaultImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:contentDescription="@string/app_intro_image_content_description"
-        app:layout_constraintBottom_toTopOf="@+id/description"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title"
-        app:layout_constraintVertical_weight="5" />
+        <TextView
+            android:id="@+id/title"
+            style="@style/AppIntroDefaultHeading"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:gravity="center"
+            app:layout_constraintBottom_toTopOf="@+id/image"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="spread"
+            app:layout_constraintVertical_weight="2"
+            tools:text="Welcome" />
 
-    <TextView
-        android:id="@+id/description"
-        style="@style/AppIntroDefaultText"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:autoLink="web"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/image"
-        app:layout_constraintVertical_weight="3"
-        tools:text="This is a demo of the AppIntro Library" />
+        <ImageView
+            android:id="@+id/image"
+            style="@style/AppIntroDefaultImage"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:contentDescription="@string/app_intro_image_content_description"
+            app:layout_constraintBottom_toTopOf="@+id/description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/title"
+            app:layout_constraintVertical_weight="5" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/description"
+            style="@style/AppIntroDefaultText"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:autoLink="web"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/image"
+            app:layout_constraintVertical_weight="3"
+            tools:text="This is a demo of the AppIntro Library" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</FrameLayout>

--- a/appintro/src/main/res/layout/appintro_intro_layout.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout.xml
@@ -35,64 +35,57 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <View
+    <FrameLayout
         android:id="@+id/bottom"
         android:layout_width="match_parent"
         android:layout_height="@dimen/appintro_bottombar_height"
         android:background="@color/appintro_bar_color"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent">
 
-    <Button
-        android:id="@+id/skip"
-        style="@style/AppIntroButtonStyleCompat"
-        android:labelFor="@string/app_intro_skip_button"
-        android:text="@string/app_intro_skip_button"
-        android:textColor="@color/appintro_icon_tint"
-        android:textSize="@dimen/appintro_skiptext_size"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        <Button
+            android:id="@+id/skip"
+            style="@style/AppIntroButtonStyleCompat"
+            android:layout_gravity="start|center_vertical"
+            android:labelFor="@string/app_intro_skip_button"
+            android:text="@string/app_intro_skip_button"
+            android:textColor="@color/appintro_icon_tint"
+            android:textSize="@dimen/appintro_skiptext_size" />
 
-    <ImageButton
-        android:id="@+id/back"
-        style="@style/AppIntroButtonStyleCompat"
-        android:contentDescription="@string/app_intro_back_button"
-        android:rotation="180"
-        android:visibility="invisible"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/bottom"
-        app:srcCompat="@drawable/ic_appintro_next" />
+        <ImageButton
+            android:id="@+id/back"
+            style="@style/AppIntroButtonStyleCompat"
+            android:layout_gravity="start|center_vertical"
+            android:contentDescription="@string/app_intro_back_button"
+            android:rotation="180"
+            android:visibility="invisible"
+            app:srcCompat="@drawable/ic_appintro_next" />
 
-    <FrameLayout
-        android:id="@+id/indicator_container"
-        style="@style/AppIntroIndicatorContainer"
-        android:layoutDirection="ltr"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/bottom"
-        tools:background="@drawable/ic_appintro_indicator" />
+        <FrameLayout
+            android:id="@+id/indicator_container"
+            style="@style/AppIntroIndicatorContainer"
+            android:layout_gravity="center"
+            android:layoutDirection="ltr"
+            tools:background="@drawable/ic_appintro_indicator" />
 
-    <ImageButton
-        android:id="@+id/next"
-        style="@style/AppIntroButtonStyleCompat"
-        android:contentDescription="@string/app_intro_next_button"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/bottom"
-        app:srcCompat="@drawable/ic_appintro_next" />
+        <ImageButton
+            android:id="@+id/next"
+            style="@style/AppIntroButtonStyleCompat"
+            android:layout_gravity="end|center_vertical"
+            android:contentDescription="@string/app_intro_next_button"
+            app:srcCompat="@drawable/ic_appintro_next" />
 
-    <Button
-        android:id="@+id/done"
-        style="@style/AppIntroButtonStyleCompat"
-        android:labelFor="@string/app_intro_done_button"
-        android:text="@string/app_intro_done_button"
-        android:textColor="@color/appintro_icon_tint"
-        android:textSize="@dimen/appintro_donetext_size"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        <Button
+            android:id="@+id/done"
+            style="@style/AppIntroButtonStyleCompat"
+            android:layout_gravity="end|center_vertical"
+            android:labelFor="@string/app_intro_done_button"
+            android:text="@string/app_intro_done_button"
+            android:textColor="@color/appintro_icon_tint"
+            android:textSize="@dimen/appintro_donetext_size"
+            android:visibility="gone" />
+
+    </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/appintro/src/main/res/layout/appintro_intro_layout2.xml
+++ b/appintro/src/main/res/layout/appintro_intro_layout2.xml
@@ -26,61 +26,53 @@
             android:overScrollMode="never" />
     </android.gesture.GestureOverlayView>
 
-    <View
+    <FrameLayout
         android:id="@+id/bottom"
         android:layout_width="0dp"
         android:layout_height="@dimen/appintro2_bottombar_height"
         android:background="@color/appintro_bar_color"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent">
 
-    <ImageButton
-        android:id="@+id/skip"
-        style="@style/AppIntro2ButtonStyleCompat"
-        android:contentDescription="@string/app_intro_skip_button"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/bottom"
-        app:srcCompat="@drawable/ic_appintro_fab_skip" />
+        <ImageButton
+            android:id="@+id/skip"
+            style="@style/AppIntro2ButtonStyleCompat"
+            android:layout_gravity="start|center_vertical"
+            android:contentDescription="@string/app_intro_skip_button"
+            app:srcCompat="@drawable/ic_appintro_fab_skip" />
 
-    <ImageButton
-        android:id="@+id/back"
-        style="@style/AppIntro2ButtonStyleCompat"
-        android:contentDescription="@string/app_intro_back_button"
-        android:rotation="180"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:srcCompat="@drawable/ic_appintro_fab_next" />
+        <ImageButton
+            android:id="@+id/back"
+            style="@style/AppIntro2ButtonStyleCompat"
+            android:layout_gravity="start|center_vertical"
+            android:contentDescription="@string/app_intro_back_button"
+            android:rotation="180"
+            android:visibility="gone"
+            app:srcCompat="@drawable/ic_appintro_fab_next" />
 
-    <FrameLayout
-        android:id="@+id/indicator_container"
-        style="@style/AppIntroIndicatorContainer"
-        android:layoutDirection="ltr"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/bottom"
-        tools:background="@drawable/ic_appintro_indicator" />
+        <FrameLayout
+            android:id="@+id/indicator_container"
+            style="@style/AppIntroIndicatorContainer"
+            android:layout_gravity="center"
+            android:layoutDirection="ltr"
+            tools:background="@drawable/ic_appintro_indicator" />
 
-    <ImageButton
-        android:id="@+id/next"
-        style="@style/AppIntro2ButtonStyleCompat"
-        android:contentDescription="@string/app_intro_next_button"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/bottom"
-        app:srcCompat="@drawable/ic_appintro_fab_next" />
+        <ImageButton
+            android:id="@+id/next"
+            style="@style/AppIntro2ButtonStyleCompat"
+            android:layout_gravity="end|center_vertical"
+            android:contentDescription="@string/app_intro_next_button"
+            app:srcCompat="@drawable/ic_appintro_fab_next" />
 
-    <ImageButton
-        android:id="@+id/done"
-        style="@style/AppIntro2ButtonStyleCompat"
-        android:contentDescription="@string/app_intro_done_button"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/bottom"
-        app:srcCompat="@drawable/ic_appintro_fab_done" />
+        <ImageButton
+            android:id="@+id/done"
+            style="@style/AppIntro2ButtonStyleCompat"
+            android:layout_gravity="end|center_vertical"
+            android:contentDescription="@string/app_intro_done_button"
+            android:visibility="gone"
+            app:srcCompat="@drawable/ic_appintro_fab_done" />
+
+    </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR resolves issue [#1263](https://github.com/AppIntro/AppIntro/issues/1263) by implementing edge-to-edge support, ensuring the app's UI extends behind the system bars for a more modern and immersive experience.

This was achieved by using ViewCompat.setOnApplyWindowInsetsListener to dynamically adjust the margins of the slide's container based on the system's window insets.

Acknowledgments
A big thank you to [Slion](https://github.com/Slion) for their initial work and proposed solution on their fork. This implementation is heavily based on their extensive testing and code, which was instrumental in resolving this issue.